### PR TITLE
Refactor job log viewer with useInfiniteQuery and dual-mode UX

### DIFF
--- a/src/client/@tanstack/react-query.gen.ts
+++ b/src/client/@tanstack/react-query.gen.ts
@@ -35,6 +35,7 @@ import {
   getActionOptions,
   getActionPlatforms,
   getActionTypes,
+  getAllConfigs,
   getAvailableOauthProviders,
   getCurrentUserInfo,
   getDemultiplexWorkflowConfig,
@@ -42,6 +43,7 @@ import {
   getFileVersions,
   getJob,
   getJobLog,
+  getJobLogPaginated,
   getJobs,
   getLatestManifest,
   getPipelineById,
@@ -181,6 +183,7 @@ import type {
   GetActionOptionsData,
   GetActionPlatformsData,
   GetActionTypesData,
+  GetAllConfigsData,
   GetAvailableOauthProvidersData,
   GetCurrentUserInfoData,
   GetDemultiplexWorkflowConfigData,
@@ -188,6 +191,7 @@ import type {
   GetFileVersionsData,
   GetJobData,
   GetJobLogData,
+  GetJobLogPaginatedData,
   GetJobsData,
   GetLatestManifestData,
   GetPipelineByIdData,
@@ -1607,6 +1611,31 @@ export const unlinkOauthProviderMutation = (
   return mutationOptions
 }
 
+export const getAllConfigsQueryKey = (options?: Options<GetAllConfigsData>) =>
+  createQueryKey('getAllConfigs', options)
+
+/**
+ * Get All Configs
+ * Retrieve all action configurations from S3.
+ *
+ * Returns all parsed action configs with their project types,
+ * platform configurations, and admin lists.
+ */
+export const getAllConfigsOptions = (options?: Options<GetAllConfigsData>) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await getAllConfigs({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      })
+      return data
+    },
+    queryKey: getAllConfigsQueryKey(options),
+  })
+}
+
 export const validateActionConfigQueryKey = (
   options: Options<ValidateActionConfigData>,
 ) => createQueryKey('validateActionConfig', options)
@@ -2320,7 +2349,7 @@ export const getJobLogQueryKey = (options: Options<GetJobLogData>) =>
  * job_id: Job UUID
  *
  * Returns:
- * List of log lines
+ * Log output as a list of strings
  */
 export const getJobLogOptions = (options: Options<GetJobLogData>) => {
   return queryOptions({
@@ -2334,6 +2363,48 @@ export const getJobLogOptions = (options: Options<GetJobLogData>) => {
       return data
     },
     queryKey: getJobLogQueryKey(options),
+  })
+}
+
+export const getJobLogPaginatedQueryKey = (
+  options: Options<GetJobLogPaginatedData>,
+) => createQueryKey('getJobLogPaginated', options)
+
+/**
+ * Get Job Log Paginated
+ * Get paginated logs for a specific batch job.
+ *
+ * This endpoint returns logs in pages, allowing clients to fetch large log files
+ * incrementally without timeouts.
+ *
+ * Args:
+ * session: Database session
+ * job_id: Job UUID
+ * limit: Maximum number of log lines to return (1-10000)
+ * next_token: Pagination token from previous response
+ * start_from_head: If true, start from oldest logs; if false, start from newest
+ *
+ * Returns:
+ * Paginated log response with events and next_token for subsequent requests
+ *
+ * Example usage:
+ * 1. First request: GET /jobs/{id}/log/paginated?limit=1000
+ * 2. Next page: GET /jobs/{id}/log/paginated?limit=1000&next_token={token}
+ */
+export const getJobLogPaginatedOptions = (
+  options: Options<GetJobLogPaginatedData>,
+) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await getJobLogPaginated({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      })
+      return data
+    },
+    queryKey: getJobLogPaginatedQueryKey(options),
   })
 }
 

--- a/src/client/sdk.gen.ts
+++ b/src/client/sdk.gen.ts
@@ -86,6 +86,8 @@ import type {
   GetActionTypesData,
   GetActionTypesErrors,
   GetActionTypesResponses,
+  GetAllConfigsData,
+  GetAllConfigsResponses,
   GetAvailableOauthProvidersData,
   GetAvailableOauthProvidersResponses,
   GetCurrentUserInfoData,
@@ -103,6 +105,9 @@ import type {
   GetJobErrors,
   GetJobLogData,
   GetJobLogErrors,
+  GetJobLogPaginatedData,
+  GetJobLogPaginatedErrors,
+  GetJobLogPaginatedResponses,
   GetJobLogResponses,
   GetJobResponses,
   GetJobsData,
@@ -977,6 +982,27 @@ export const unlinkOauthProvider = <ThrowOnError extends boolean = false>(
 }
 
 /**
+ * Get All Configs
+ * Retrieve all action configurations from S3.
+ *
+ * Returns all parsed action configs with their project types,
+ * platform configurations, and admin lists.
+ */
+export const getAllConfigs = <ThrowOnError extends boolean = false>(
+  options?: Options<GetAllConfigsData, ThrowOnError>,
+) => {
+  return (options?.client ?? _heyApiClient).get<
+    GetAllConfigsResponses,
+    unknown,
+    ThrowOnError
+  >({
+    responseType: 'json',
+    url: '/api/v1/actions/configs',
+    ...options,
+  })
+}
+
+/**
  * Validate Action Config
  * Validate an action configuration file from S3.
  *
@@ -1393,7 +1419,7 @@ export const updateJob = <ThrowOnError extends boolean = false>(
  * job_id: Job UUID
  *
  * Returns:
- * List of log lines
+ * Log output as a list of strings
  */
 export const getJobLog = <ThrowOnError extends boolean = false>(
   options: Options<GetJobLogData, ThrowOnError>,
@@ -1405,6 +1431,41 @@ export const getJobLog = <ThrowOnError extends boolean = false>(
   >({
     responseType: 'json',
     url: '/api/v1/jobs/{job_id}/log',
+    ...options,
+  })
+}
+
+/**
+ * Get Job Log Paginated
+ * Get paginated logs for a specific batch job.
+ *
+ * This endpoint returns logs in pages, allowing clients to fetch large log files
+ * incrementally without timeouts.
+ *
+ * Args:
+ * session: Database session
+ * job_id: Job UUID
+ * limit: Maximum number of log lines to return (1-10000)
+ * next_token: Pagination token from previous response
+ * start_from_head: If true, start from oldest logs; if false, start from newest
+ *
+ * Returns:
+ * Paginated log response with events and next_token for subsequent requests
+ *
+ * Example usage:
+ * 1. First request: GET /jobs/{id}/log/paginated?limit=1000
+ * 2. Next page: GET /jobs/{id}/log/paginated?limit=1000&next_token={token}
+ */
+export const getJobLogPaginated = <ThrowOnError extends boolean = false>(
+  options: Options<GetJobLogPaginatedData, ThrowOnError>,
+) => {
+  return (options.client ?? _heyApiClient).get<
+    GetJobLogPaginatedResponses,
+    GetJobLogPaginatedErrors,
+    ThrowOnError
+  >({
+    responseType: 'json',
+    url: '/api/v1/jobs/{job_id}/log/paginated',
     ...options,
   })
 }

--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -143,6 +143,21 @@ export type ActionConfig = {
 }
 
 /**
+ * ActionConfigsResponse
+ * Response model for list of action workflow configurations.
+ */
+export type ActionConfigsResponse = {
+  /**
+   * Configs
+   */
+  configs: Array<ActionConfig>
+  /**
+   * Total
+   */
+  total: number
+}
+
+/**
  * ActionInput
  * Model for action input configuration.
  */
@@ -929,6 +944,17 @@ export type FilesPublic = {
 }
 
 /**
+ * HTTPErrorResponse
+ * Schema matching FastAPI's HTTPException response body.
+ */
+export type HttpErrorResponse = {
+  /**
+   * Detail
+   */
+  detail: string
+}
+
+/**
  * HTTPValidationError
  */
 export type HttpValidationError = {
@@ -1054,6 +1080,29 @@ export type JobStatus =
   | 'RUNNING'
   | 'SUCCEEDED'
   | 'FAILED'
+
+/**
+ * LogResponse
+ * Response model for paginated log retrieval.
+ */
+export type LogResponse = {
+  /**
+   * Events
+   */
+  events: Array<string>
+  /**
+   * Next Token
+   */
+  next_token?: string | null
+  /**
+   * Has More
+   */
+  has_more?: boolean
+  /**
+   * Total Events
+   */
+  total_events?: number
+}
 
 /**
  * ManifestUploadResponse
@@ -1457,7 +1506,7 @@ export type ProjectCreate = {
   /**
    * Attributes
    */
-  attributes?: Array<Attribute> | null
+  attributes?: Array<ApiProjectModelsAttribute> | null
 }
 
 /**
@@ -1483,7 +1532,7 @@ export type ProjectPublic = {
   /**
    * Attributes
    */
-  attributes: Array<Attribute> | null
+  attributes: Array<ApiProjectModelsAttribute> | null
   /**
    * Sequencing Runs
    */
@@ -1502,7 +1551,7 @@ export type ProjectUpdate = {
   /**
    * Attributes
    */
-  attributes?: Array<Attribute> | null
+  attributes?: Array<ApiProjectModelsAttribute> | null
 }
 
 /**
@@ -1844,7 +1893,7 @@ export type SampleCreate = {
   /**
    * Attributes
    */
-  attributes?: Array<ApiSamplesModelsAttribute> | null
+  attributes?: Array<Attribute> | null
 }
 
 /**
@@ -1877,7 +1926,7 @@ export type SamplePublic = {
   /**
    * Attributes
    */
-  attributes: Array<ApiSamplesModelsAttribute> | null
+  attributes: Array<Attribute> | null
 }
 
 /**
@@ -2647,7 +2696,7 @@ export type WorkflowSummary = {
 /**
  * Attribute
  */
-export type ApiSamplesModelsAttribute = {
+export type ApiProjectModelsAttribute = {
   /**
    * Key
    */
@@ -3259,6 +3308,23 @@ export type UnlinkOauthProviderResponses = {
 export type UnlinkOauthProviderResponse =
   UnlinkOauthProviderResponses[keyof UnlinkOauthProviderResponses]
 
+export type GetAllConfigsData = {
+  body?: never
+  path?: never
+  query?: never
+  url: '/api/v1/actions/configs'
+}
+
+export type GetAllConfigsResponses = {
+  /**
+   * Successful Response
+   */
+  200: ActionConfigsResponse
+}
+
+export type GetAllConfigsResponse =
+  GetAllConfigsResponses[keyof GetAllConfigsResponses]
+
 export type ValidateActionConfigData = {
   body?: never
   path?: never
@@ -3688,6 +3754,10 @@ export type GetJobData = {
 
 export type GetJobErrors = {
   /**
+   * Job not found
+   */
+  404: HttpErrorResponse
+  /**
    * Validation Error
    */
   422: HttpValidationError
@@ -3717,6 +3787,10 @@ export type UpdateJobData = {
 }
 
 export type UpdateJobErrors = {
+  /**
+   * Job not found
+   */
+  404: HttpErrorResponse
   /**
    * Validation Error
    */
@@ -3748,6 +3822,10 @@ export type GetJobLogData = {
 
 export type GetJobLogErrors = {
   /**
+   * Job not found
+   */
+  404: HttpErrorResponse
+  /**
    * Validation Error
    */
   422: HttpValidationError
@@ -3764,6 +3842,58 @@ export type GetJobLogResponses = {
 }
 
 export type GetJobLogResponse = GetJobLogResponses[keyof GetJobLogResponses]
+
+export type GetJobLogPaginatedData = {
+  body?: never
+  path: {
+    /**
+     * Job Id
+     */
+    job_id: string
+  }
+  query?: {
+    /**
+     * Limit
+     * Number of log lines to return
+     */
+    limit?: number
+    /**
+     * Next Token
+     * Token for next page of results
+     */
+    next_token?: string | null
+    /**
+     * Start From Head
+     * Start from beginning (true) or end (false)
+     */
+    start_from_head?: boolean
+  }
+  url: '/api/v1/jobs/{job_id}/log/paginated'
+}
+
+export type GetJobLogPaginatedErrors = {
+  /**
+   * Job not found
+   */
+  404: HttpErrorResponse
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError
+}
+
+export type GetJobLogPaginatedError =
+  GetJobLogPaginatedErrors[keyof GetJobLogPaginatedErrors]
+
+export type GetJobLogPaginatedResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogResponse
+}
+
+export type GetJobLogPaginatedResponse =
+  GetJobLogPaginatedResponses[keyof GetJobLogPaginatedResponses]
 
 export type GetLatestManifestData = {
   body?: never
@@ -4167,7 +4297,7 @@ export type AddSampleToProjectResponse =
   AddSampleToProjectResponses[keyof AddSampleToProjectResponses]
 
 export type UpdateSampleInProjectData = {
-  body: ApiSamplesModelsAttribute
+  body: Attribute
   path: {
     /**
      * Sample Id

--- a/src/hooks/use-job-log.ts
+++ b/src/hooks/use-job-log.ts
@@ -1,0 +1,239 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  useInfiniteQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
+import type { InfiniteData } from '@tanstack/react-query'
+import type { LogResponse } from '@/client'
+import { getJobLogPaginated } from '@/client'
+import { getJobLogPaginatedQueryKey } from '@/client/@tanstack/react-query.gen'
+
+// Adjust these constants for log fetching behavior
+const LOG_PAGE_LIMIT = 100
+const POLL_INTERVAL_MS = 5000
+const FETCH_THRESHOLD_PX = 80
+const INDICATOR_THRESHOLD_MIN_PX = 400
+const INDICATOR_THRESHOLD_RATIO = 0.20
+
+// --------------------------------------------------------------------------
+// Hook: useJobLog
+//
+// Manages paginated log fetching for a batch job with two modes:
+//
+//   Live mode  (job is RUNNING):
+//     - Auto-walks all existing pages on mount
+//     - Polls every 5s for new events (append-only, no re-fetch)
+//     - Auto-scrolls viewport to bottom when pinned
+//
+//   Browse mode (job is SUCCEEDED / FAILED / etc.):
+//     - Loads only the initial page
+//     - User scrolls to load more (infinite scroll)
+//     - Shows "Scroll to load more" indicator near the bottom
+// --------------------------------------------------------------------------
+
+export function useJobLog(jobId: string, isLive: boolean) {
+  const queryClient = useQueryClient()
+
+  // ── Query setup ──────────────────────────────────────────────────────
+
+  const queryKey = useMemo(
+    () =>
+      [
+        ...getJobLogPaginatedQueryKey({
+          path: { job_id: jobId },
+          query: { limit: LOG_PAGE_LIMIT, start_from_head: true },
+        }),
+        'infinite',
+      ] as const,
+    [jobId],
+  )
+
+  const {
+    data,
+    error,
+    status,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery<
+    LogResponse,
+    Error,
+    InfiniteData<LogResponse, string | undefined>,
+    typeof queryKey,
+    string | undefined
+  >({
+    queryKey,
+    queryFn: async ({ pageParam, signal }) => {
+      const { data: logData } = await getJobLogPaginated({
+        path: { job_id: jobId },
+        query: {
+          limit: LOG_PAGE_LIMIT,
+          next_token: pageParam ?? undefined,
+          start_from_head: true,
+        },
+        signal,
+        throwOnError: true,
+      })
+      return logData!
+    },
+    initialPageParam: undefined,
+    getNextPageParam: (lastPage) =>
+      lastPage.has_more && lastPage.next_token
+        ? lastPage.next_token
+        : undefined,
+  })
+
+  // ── Scroll state ─────────────────────────────────────────────────────
+
+  const scrollAreaRef = useRef<HTMLDivElement>(null)
+
+  // True when the user is within FETCH_THRESHOLD_PX of the bottom.
+  // In live mode, starts true so auto-scroll kicks in immediately.
+  const isAtBottomRef = useRef(isLive)
+
+  // Drives the "Scroll to load more" overlay visibility (browse mode).
+  const [isNearBottom, setIsNearBottom] = useState(false)
+
+  // Reset when new content loads — viewport is no longer near the bottom.
+  useEffect(() => {
+    setIsNearBottom(false)
+  }, [data])
+
+  // ── Live mode: auto-walk all pages ───────────────────────────────────
+
+  useEffect(() => {
+    if (isLive && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage()
+    }
+  }, [isLive, hasNextPage, isFetchingNextPage, fetchNextPage])
+
+  // ── Browse mode: auto-fill until viewport is scrollable ──────────────
+
+  useEffect(() => {
+    if (isLive) return
+    const viewport = getViewport()
+    if (!viewport) return
+    if (viewport.scrollHeight <= viewport.clientHeight && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage()
+    }
+  }, [isLive, data, hasNextPage, isFetchingNextPage, fetchNextPage])
+
+  // ── Scroll handler ───────────────────────────────────────────────────
+  // Re-attaches when query state changes. Updates isAtBottomRef (for live
+  // auto-scroll) and isNearBottom state (for browse overlay). In browse
+  // mode, triggers fetchNextPage when the user scrolls near the bottom.
+
+  useEffect(() => {
+    const viewport = getViewport()
+    if (!viewport) return
+
+    let lastScrollTop = viewport.scrollTop
+    const onScroll = () => {
+      const distanceFromBottom =
+        viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight
+      const indicatorThreshold = Math.max(
+        INDICATOR_THRESHOLD_MIN_PX,
+        viewport.scrollHeight * INDICATOR_THRESHOLD_RATIO,
+      )
+      const scrollingDown = viewport.scrollTop >= lastScrollTop
+      lastScrollTop = viewport.scrollTop
+
+      isAtBottomRef.current = distanceFromBottom < FETCH_THRESHOLD_PX
+      setIsNearBottom(scrollingDown && distanceFromBottom < indicatorThreshold)
+
+      if (
+        !isLive &&
+        distanceFromBottom < FETCH_THRESHOLD_PX &&
+        hasNextPage &&
+        !isFetchingNextPage
+      ) {
+        fetchNextPage()
+      }
+    }
+
+    viewport.addEventListener('scroll', onScroll, { passive: true })
+    return () => viewport.removeEventListener('scroll', onScroll)
+  }, [isLive, hasNextPage, isFetchingNextPage, fetchNextPage])
+
+  // ── Live polling: append-only, never re-fetch old pages ──────────────
+
+  useEffect(() => {
+    if (!isLive) return
+    if (status !== 'success') return
+
+    const controller = new AbortController()
+
+    const pollOnce = async () => {
+      if (isFetchingNextPage) return
+
+      const cache = queryClient.getQueryData<
+        InfiniteData<LogResponse, string | undefined>
+      >(queryKey)
+      if (!cache || cache.pages.length === 0) return
+
+      const lastPage = cache.pages[cache.pages.length - 1]
+      const lastToken = lastPage.next_token
+      if (!lastToken) return
+
+      const { data: newPageData } = await getJobLogPaginated({
+        path: { job_id: jobId },
+        query: {
+          limit: LOG_PAGE_LIMIT,
+          next_token: lastToken,
+          start_from_head: true,
+        },
+        signal: controller.signal,
+        throwOnError: true,
+      })
+      if (!newPageData || newPageData.events.length === 0) return
+
+      queryClient.setQueryData<
+        InfiniteData<LogResponse, string | undefined>
+      >(queryKey, (old) => {
+        if (!old) return old
+        return {
+          pages: [...old.pages, newPageData],
+          pageParams: [...old.pageParams, lastToken],
+        }
+      })
+    }
+
+    const id = setInterval(() => { void pollOnce() }, POLL_INTERVAL_MS)
+    return () => {
+      clearInterval(id)
+      controller.abort()
+    }
+  }, [isLive, status, jobId, queryClient, queryKey, isFetchingNextPage])
+
+  // ── Live auto-scroll: pin to bottom when data changes ────────────────
+
+  useEffect(() => {
+    if (!isLive || !isAtBottomRef.current) return
+    const viewport = getViewport()
+    if (viewport) {
+      viewport.scrollTop = viewport.scrollHeight
+    }
+  }, [isLive, data])
+
+  // ── Helpers ──────────────────────────────────────────────────────────
+
+  function getViewport() {
+    return scrollAreaRef.current?.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]',
+    ) ?? null
+  }
+
+  // ── Public API ───────────────────────────────────────────────────────
+
+  const lines = data?.pages.flatMap((page) => page.events) ?? []
+
+  return {
+    lines,
+    error,
+    status,
+    hasNextPage,
+    isFetchingNextPage,
+    isNearBottom,
+    scrollAreaRef,
+  }
+}

--- a/src/routes/_auth.jobs.$job_id.index.tsx
+++ b/src/routes/_auth.jobs.$job_id.index.tsx
@@ -1,26 +1,13 @@
 import { createFileRoute, getRouteApi } from '@tanstack/react-router'
-import { Calendar, FileText, Server, Terminal, User } from 'lucide-react'
-import {
-  useInfiniteQuery,
-  useQuery,
-  useQueryClient,
-} from '@tanstack/react-query'
-import { useEffect, useMemo, useRef } from 'react'
-import type { InfiniteData } from '@tanstack/react-query'
-import type { LogResponse } from '@/client'
+import { Calendar, ChevronDown, FileText, Server, Terminal, User } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { CopyableText } from '@/components/copyable-text'
 import { JobStatusBadge } from '@/components/job-status-badge'
 import { Separator } from '@/components/ui/separator'
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area'
-import { getJobLogPaginated } from '@/client'
-import {
-  getJobLogPaginatedQueryKey,
-  getJobOptions,
-} from '@/client/@tanstack/react-query.gen'
-
-const LOG_PAGE_LIMIT = 1000
-const LOG_POLL_INTERVAL_MS = 5000
+import { getJobOptions } from '@/client/@tanstack/react-query.gen'
+import { useJobLog } from '@/hooks/use-job-log'
 
 export const Route = createFileRoute('/_auth/jobs/$job_id/')({
   component: RouteComponent,
@@ -44,171 +31,19 @@ function RouteComponent() {
     refetchIntervalInBackground: true,
   })
 
-  const shouldPollJobLog = ['RUNNING'].includes(job.status)
-
-  const queryClient = useQueryClient()
-
-  const jobLogQueryKey = useMemo(
-    () =>
-      [
-        ...getJobLogPaginatedQueryKey({
-          path: { job_id: job.id },
-          query: { limit: LOG_PAGE_LIMIT, start_from_head: true },
-        }),
-        'infinite',
-      ] as const,
-    [job.id],
-  )
+  const isLive = job.status === 'RUNNING'
 
   const {
-    data: jobLogData,
+    lines,
     error: jobLogError,
     status: jobLogStatus,
-    fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useInfiniteQuery<
-    LogResponse,
-    Error,
-    InfiniteData<LogResponse, string | undefined>,
-    typeof jobLogQueryKey,
-    string | undefined
-  >({
-    queryKey: jobLogQueryKey,
-    queryFn: async ({ pageParam, signal }) => {
-      const { data } = await getJobLogPaginated({
-        path: { job_id: job.id },
-        query: {
-          limit: LOG_PAGE_LIMIT,
-          next_token: pageParam ?? undefined,
-          start_from_head: true,
-        },
-        signal,
-        throwOnError: true,
-      })
-      return data!
-    },
-    initialPageParam: undefined,
-    getNextPageParam: (lastPage) =>
-      lastPage.has_more && lastPage.next_token
-        ? lastPage.next_token
-        : undefined,
-  })
+    isNearBottom,
+    scrollAreaRef,
+  } = useJobLog(job.id, isLive)
 
-  // Auto-walk: drain hasNextPage until the initial load reaches the tail.
-  // Also fires again after the polling effect appends a page whose has_more
-  // is true (a backlog built up between polls).
-  useEffect(() => {
-    if (hasNextPage && !isFetchingNextPage) {
-      fetchNextPage()
-    }
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
-
-  // Mirror isFetchingNextPage into a ref so the polling effect can read the
-  // latest value without tearing down its interval every time the flag toggles
-  // during the initial walk.
-  const isFetchingNextPageRef = useRef(isFetchingNextPage)
-  useEffect(() => {
-    isFetchingNextPageRef.current = isFetchingNextPage
-  }, [isFetchingNextPage])
-
-  // Append-only polling: while the job is running, every 5s fetch a single
-  // page starting from the last cached page's next_token and append it to
-  // the infinite query data. Previously loaded pages are never re-fetched.
-  useEffect(() => {
-    if (!shouldPollJobLog) return
-    if (jobLogStatus !== 'success') return
-
-    const controller = new AbortController()
-
-    const pollOnce = async () => {
-      // Don't interleave with the auto-walk effect.
-      if (isFetchingNextPageRef.current) return
-
-      const cache = queryClient.getQueryData<
-        InfiniteData<LogResponse, string | undefined>
-      >(jobLogQueryKey)
-      if (!cache || cache.pages.length === 0) return
-
-      const lastPage = cache.pages[cache.pages.length - 1]
-      const lastToken = lastPage.next_token
-      if (!lastToken) return
-
-      const { data } = await getJobLogPaginated({
-        path: { job_id: job.id },
-        query: {
-          limit: LOG_PAGE_LIMIT,
-          next_token: lastToken,
-          start_from_head: true,
-        },
-        signal: controller.signal,
-        throwOnError: true,
-      })
-      if (!data || data.events.length === 0) return
-
-      queryClient.setQueryData<
-        InfiniteData<LogResponse, string | undefined>
-      >(jobLogQueryKey, (old) => {
-        if (!old) return old
-        return {
-          pages: [...old.pages, data],
-          pageParams: [...old.pageParams, lastToken],
-        }
-      })
-    }
-
-    const id = setInterval(() => {
-      void pollOnce()
-    }, LOG_POLL_INTERVAL_MS)
-    return () => {
-      clearInterval(id)
-      controller.abort()
-    }
-  }, [
-    shouldPollJobLog,
-    jobLogStatus,
-    job.id,
-    queryClient,
-    jobLogQueryKey,
-  ])
-
-  // Auto-scroll: pin the log to the bottom while the user hasn't scrolled up.
-  // We track whether the viewport is "near the bottom" and only scroll when it is.
-  const logEndRef = useRef<HTMLDivElement>(null)
-  const scrollAreaRef = useRef<HTMLDivElement>(null)
-  const isNearBottomRef = useRef(true)
-
-  useEffect(() => {
-    const viewport = scrollAreaRef.current?.querySelector<HTMLElement>(
-      '[data-slot="scroll-area-viewport"]',
-    )
-    if (!viewport) return
-
-    const onScroll = () => {
-      const threshold = 50
-      isNearBottomRef.current =
-        viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight <
-        threshold
-    }
-
-    viewport.addEventListener('scroll', onScroll, { passive: true })
-    return () => viewport.removeEventListener('scroll', onScroll)
-  }, [])
-
-  const isAutoWalking = hasNextPage || isFetchingNextPage
-  useEffect(() => {
-    if (isNearBottomRef.current) {
-      // Use instant scroll during rapid page loading so the smooth-scroll
-      // animation doesn't fall behind and accidentally un-pin the viewport.
-      logEndRef.current?.scrollIntoView({
-        behavior: isAutoWalking ? 'instant' : 'smooth',
-      })
-    }
-  })
-
-  const jobLogLines =
-    jobLogData?.pages.flatMap((page) => page.events) ?? []
-  const jobLogText = jobLogLines
+  const jobLogText = lines
     .map((line, index) => `${index + 1}: ${line}`)
     .join('\n')
   const jobLogErrorMessage = jobLogError instanceof Error
@@ -305,7 +140,7 @@ function RouteComponent() {
       <Card className="border-0 shadow-none">
         <CardHeader className="flex flex-row items-center justify-between space-y-0">
           <CardTitle>Job Log</CardTitle>
-          {shouldPollJobLog ? (
+          {isLive ? (
             <span className="inline-flex items-center gap-2 text-xs text-muted-foreground">
               <span className="h-2 w-2 rounded-full bg-primary animate-pulse" />
               Live updating
@@ -313,24 +148,39 @@ function RouteComponent() {
           ) : null}
         </CardHeader>
         <CardContent>
-          <ScrollArea ref={scrollAreaRef} className="h-[500px] rounded-lg border border-border bg-muted">
-            {jobLogStatus === 'pending' ? (
-              <div className="p-4 text-sm text-muted-foreground">Loading job log...</div>
-            ) : jobLogError ? (
-              <div className="p-4 text-sm text-destructive">Failed to load job log: {jobLogErrorMessage}</div>
-            ) : (
-              <div className="p-4 font-mono text-sm text-muted-foreground whitespace-pre">
-                {jobLogText.length > 0
-                  ? jobLogText
-                  : 'No job log output is available yet.'}
-                {isFetchingNextPage && jobLogLines.length > 0 ? (
-                  <div className="pt-2 text-xs text-muted-foreground italic">Loading more...</div>
-                ) : null}
-                <div ref={logEndRef} />
-              </div>
-            )}
-            <ScrollBar orientation="horizontal" />
-          </ScrollArea>
+          <div className="relative">
+            <ScrollArea ref={scrollAreaRef} className="h-[500px] rounded-lg border border-border bg-muted">
+              {jobLogStatus === 'pending' ? (
+                <div className="p-4 text-sm text-muted-foreground">Loading job log...</div>
+              ) : jobLogError ? (
+                <div className="p-4 text-sm text-destructive">Failed to load job log: {jobLogErrorMessage}</div>
+              ) : (
+                <div className="p-4 font-mono text-sm text-muted-foreground whitespace-pre">
+                  {jobLogText.length > 0
+                    ? jobLogText
+                    : 'No job log output is available yet.'}
+                </div>
+              )}
+              <ScrollBar orientation="horizontal" />
+            </ScrollArea>
+            {!isLive && hasNextPage && (isNearBottom || isFetchingNextPage) ? (
+              <>
+                <div className="absolute inset-0 pointer-events-none rounded-lg bg-gradient-to-b from-transparent from-90% to-white" />
+                <div className="absolute inset-x-0 bottom-4 flex justify-center pointer-events-none">
+                  <span className="inline-flex items-center gap-1.5 rounded-md bg-secondary px-3 py-1.5 text-xs font-medium text-secondary-foreground shadow-sm">
+                    {isFetchingNextPage ? (
+                      <>Loading more...</>
+                    ) : (
+                      <>
+                        <ChevronDown className="h-3.5 w-3.5" />
+                        Scroll to load more
+                      </>
+                    )}
+                  </span>
+                </div>
+              </>
+            ) : null}
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/src/routes/_auth.jobs.$job_id.index.tsx
+++ b/src/routes/_auth.jobs.$job_id.index.tsx
@@ -1,12 +1,26 @@
 import { createFileRoute, getRouteApi } from '@tanstack/react-router'
 import { Calendar, FileText, Server, Terminal, User } from 'lucide-react'
-import { useQuery } from '@tanstack/react-query'
+import {
+  useInfiniteQuery,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
+import { useEffect, useMemo, useRef } from 'react'
+import type { InfiniteData } from '@tanstack/react-query'
+import type { LogResponse } from '@/client'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { CopyableText } from '@/components/copyable-text'
 import { JobStatusBadge } from '@/components/job-status-badge'
 import { Separator } from '@/components/ui/separator'
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area'
-import { getJobLogOptions, getJobOptions } from '@/client/@tanstack/react-query.gen'
+import { getJobLogPaginated } from '@/client'
+import {
+  getJobLogPaginatedQueryKey,
+  getJobOptions,
+} from '@/client/@tanstack/react-query.gen'
+
+const LOG_PAGE_LIMIT = 1000
+const LOG_POLL_INTERVAL_MS = 5000
 
 export const Route = createFileRoute('/_auth/jobs/$job_id/')({
   component: RouteComponent,
@@ -32,18 +46,170 @@ function RouteComponent() {
 
   const shouldPollJobLog = ['RUNNING'].includes(job.status)
 
-  const { data: jobLog, isLoading: isJobLogLoading, error: jobLogError } = useQuery({
-    ...getJobLogOptions({
-      path: {
-        job_id: job.id,
-      }
-    }),
-    refetchInterval: shouldPollJobLog ? 5000 : false,
-    refetchIntervalInBackground: true,
+  const queryClient = useQueryClient()
+
+  const jobLogQueryKey = useMemo(
+    () =>
+      [
+        ...getJobLogPaginatedQueryKey({
+          path: { job_id: job.id },
+          query: { limit: LOG_PAGE_LIMIT, start_from_head: true },
+        }),
+        'infinite',
+      ] as const,
+    [job.id],
+  )
+
+  const {
+    data: jobLogData,
+    error: jobLogError,
+    status: jobLogStatus,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery<
+    LogResponse,
+    Error,
+    InfiniteData<LogResponse, string | undefined>,
+    typeof jobLogQueryKey,
+    string | undefined
+  >({
+    queryKey: jobLogQueryKey,
+    queryFn: async ({ pageParam, signal }) => {
+      const { data } = await getJobLogPaginated({
+        path: { job_id: job.id },
+        query: {
+          limit: LOG_PAGE_LIMIT,
+          next_token: pageParam ?? undefined,
+          start_from_head: true,
+        },
+        signal,
+        throwOnError: true,
+      })
+      return data!
+    },
+    initialPageParam: undefined,
+    getNextPageParam: (lastPage) =>
+      lastPage.has_more && lastPage.next_token
+        ? lastPage.next_token
+        : undefined,
   })
 
-  const jobLogText = jobLog
-    ?.map((line, index) => `${index + 1}: ${line}`)
+  // Auto-walk: drain hasNextPage until the initial load reaches the tail.
+  // Also fires again after the polling effect appends a page whose has_more
+  // is true (a backlog built up between polls).
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage()
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
+
+  // Mirror isFetchingNextPage into a ref so the polling effect can read the
+  // latest value without tearing down its interval every time the flag toggles
+  // during the initial walk.
+  const isFetchingNextPageRef = useRef(isFetchingNextPage)
+  useEffect(() => {
+    isFetchingNextPageRef.current = isFetchingNextPage
+  }, [isFetchingNextPage])
+
+  // Append-only polling: while the job is running, every 5s fetch a single
+  // page starting from the last cached page's next_token and append it to
+  // the infinite query data. Previously loaded pages are never re-fetched.
+  useEffect(() => {
+    if (!shouldPollJobLog) return
+    if (jobLogStatus !== 'success') return
+
+    const controller = new AbortController()
+
+    const pollOnce = async () => {
+      // Don't interleave with the auto-walk effect.
+      if (isFetchingNextPageRef.current) return
+
+      const cache = queryClient.getQueryData<
+        InfiniteData<LogResponse, string | undefined>
+      >(jobLogQueryKey)
+      if (!cache || cache.pages.length === 0) return
+
+      const lastPage = cache.pages[cache.pages.length - 1]
+      const lastToken = lastPage.next_token
+      if (!lastToken) return
+
+      const { data } = await getJobLogPaginated({
+        path: { job_id: job.id },
+        query: {
+          limit: LOG_PAGE_LIMIT,
+          next_token: lastToken,
+          start_from_head: true,
+        },
+        signal: controller.signal,
+        throwOnError: true,
+      })
+      if (!data || data.events.length === 0) return
+
+      queryClient.setQueryData<
+        InfiniteData<LogResponse, string | undefined>
+      >(jobLogQueryKey, (old) => {
+        if (!old) return old
+        return {
+          pages: [...old.pages, data],
+          pageParams: [...old.pageParams, lastToken],
+        }
+      })
+    }
+
+    const id = setInterval(() => {
+      void pollOnce()
+    }, LOG_POLL_INTERVAL_MS)
+    return () => {
+      clearInterval(id)
+      controller.abort()
+    }
+  }, [
+    shouldPollJobLog,
+    jobLogStatus,
+    job.id,
+    queryClient,
+    jobLogQueryKey,
+  ])
+
+  // Auto-scroll: pin the log to the bottom while the user hasn't scrolled up.
+  // We track whether the viewport is "near the bottom" and only scroll when it is.
+  const logEndRef = useRef<HTMLDivElement>(null)
+  const scrollAreaRef = useRef<HTMLDivElement>(null)
+  const isNearBottomRef = useRef(true)
+
+  useEffect(() => {
+    const viewport = scrollAreaRef.current?.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]',
+    )
+    if (!viewport) return
+
+    const onScroll = () => {
+      const threshold = 50
+      isNearBottomRef.current =
+        viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight <
+        threshold
+    }
+
+    viewport.addEventListener('scroll', onScroll, { passive: true })
+    return () => viewport.removeEventListener('scroll', onScroll)
+  }, [])
+
+  const isAutoWalking = hasNextPage || isFetchingNextPage
+  useEffect(() => {
+    if (isNearBottomRef.current) {
+      // Use instant scroll during rapid page loading so the smooth-scroll
+      // animation doesn't fall behind and accidentally un-pin the viewport.
+      logEndRef.current?.scrollIntoView({
+        behavior: isAutoWalking ? 'instant' : 'smooth',
+      })
+    }
+  })
+
+  const jobLogLines =
+    jobLogData?.pages.flatMap((page) => page.events) ?? []
+  const jobLogText = jobLogLines
+    .map((line, index) => `${index + 1}: ${line}`)
     .join('\n')
   const jobLogErrorMessage = jobLogError instanceof Error
     ? jobLogError.message
@@ -147,16 +313,20 @@ function RouteComponent() {
           ) : null}
         </CardHeader>
         <CardContent>
-          <ScrollArea className="h-[500px] rounded-lg border border-border bg-muted">
-            {isJobLogLoading ? (
+          <ScrollArea ref={scrollAreaRef} className="h-[500px] rounded-lg border border-border bg-muted">
+            {jobLogStatus === 'pending' ? (
               <div className="p-4 text-sm text-muted-foreground">Loading job log...</div>
             ) : jobLogError ? (
               <div className="p-4 text-sm text-destructive">Failed to load job log: {jobLogErrorMessage}</div>
             ) : (
               <div className="p-4 font-mono text-sm text-muted-foreground whitespace-pre">
-                {jobLogText && jobLogText.length > 0
+                {jobLogText.length > 0
                   ? jobLogText
                   : 'No job log output is available yet.'}
+                {isFetchingNextPage && jobLogLines.length > 0 ? (
+                  <div className="pt-2 text-xs text-muted-foreground italic">Loading more...</div>
+                ) : null}
+                <div ref={logEndRef} />
               </div>
             )}
             <ScrollBar orientation="horizontal" />


### PR DESCRIPTION
## Summary
- Extract job log logic into a reusable `useJobLog` hook with two modes driven by job state:
  - **Live mode** (RUNNING): auto-walks all pages, polls every 5s for new events (append-only, never re-fetches old pages), and auto-scrolls to keep the viewport pinned to the bottom
  - **Browse mode** (SUCCEEDED/FAILED): loads initial page, user scrolls to load more with a gradient overlay and "Scroll to load more" indicator
- Replace the old `useQuery` + manual cursor loop with `useInfiniteQuery` for proper page-by-page caching
- Indicator only appears when scrolling down near the end of loaded content, dismisses on scroll up
- Regenerated API client with `getJobLogPaginated` endpoint and `LogResponse` type

## Test plan
- [x] Navigate to a completed job — verify initial page loads, "Scroll to load more" appears near bottom, scrolling loads more pages, no polling in network tab
- [x] Navigate to a running job — verify pages auto-walk on mount, "Live updating" pulse visible, new events appear every ~5s, viewport stays pinned to bottom
- [x] On a running job, scroll up — verify auto-scroll stops and user can read freely; scrolling back to bottom resumes auto-scroll
- [x] Observe a running job that finishes — verify polling stops and browse mode takes over
- [x] Navigate to a job with no logs yet — verify "No job log output is available yet." fallback
- [x] Navigate away mid-load — verify requests abort cleanly (no console errors)