### PR TITLE
Add unified error-handling system (ErrorState/Banner/toast/form)

### DIFF
--- a/src/components/add-vendor-form.tsx
+++ b/src/components/add-vendor-form.tsx
@@ -8,11 +8,11 @@ import { useId, useState } from "react";
 import type React from "react";
 import type { JSX } from "react";
 import type { SubmitHandler } from "react-hook-form";
-import type { HttpValidationError, VendorPublic } from "@/client";
-import type { AxiosError } from "axios";
+import type { VendorPublic } from "@/client";
 import { Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet"
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
+import { getFormApiErrorMessage } from "@/lib/error-utils";
 import { Input } from "@/components/ui/input";
 import { addVendorMutation, getVendorsQueryKey } from "@/client/@tanstack/react-query.gen";
 import { Textarea } from "@/components/ui/textarea";
@@ -72,10 +72,8 @@ export const AddVendorForm: React.FC<AddVendorFormProps> = ({
   const queryClient = useQueryClient();
   const { mutate, isPending } = useMutation({
     ...addVendorMutation(),
-    onError: (error: AxiosError<HttpValidationError>) => {
-      const message = error.response?.data.detail?.toString()
-        || "An unknown error occurred.";
-      setError("root", { message });
+    onError: (error) => {
+      setError("root", { message: getFormApiErrorMessage(error, "An unknown error occurred.") });
     },
     onSuccess: (data: VendorPublic) => {
       reset();

--- a/src/components/api-keys-section.tsx
+++ b/src/components/api-keys-section.tsx
@@ -15,6 +15,7 @@ import {
   listApiKeysQueryKey,
   revokeApiKeyMutation,
 } from '@/client/@tanstack/react-query.gen'
+import { getFormApiErrorMessage, toastApiError } from '@/lib/error-utils'
 import { ServerDataTable } from '@/components/data-table/data-table'
 import { SortableHeader } from '@/components/data-table/sortable-header'
 import { CopyableText } from '@/components/copyable-text'
@@ -72,10 +73,8 @@ function CreateApiKeyButton({
 
   const { mutate, isPending } = useMutation({
     ...createApiKeyMutation(),
-    onError: (error: any) => {
-      const message =
-        error.response?.data?.detail?.toString() || 'Failed to create API key.'
-      setError('root', { message })
+    onError: (error) => {
+      setError('root', { message: getFormApiErrorMessage(error, 'Failed to create API key.') })
     },
     onSuccess: (data: ApiKeyCreateResponse) => {
       reset()
@@ -292,8 +291,8 @@ export function APIKeysSection() {
       setConfirmAction(null)
       queryClient.invalidateQueries({ queryKey: listApiKeysQueryKey() })
     },
-    onError: (error: any) => {
-      toast.error(error.response?.data?.detail?.toString() || 'Failed to revoke API key')
+    onError: (error) => {
+      toastApiError(error, 'Failed to revoke API key')
     },
   })
 
@@ -305,8 +304,8 @@ export function APIKeysSection() {
       setConfirmAction(null)
       queryClient.invalidateQueries({ queryKey: listApiKeysQueryKey() })
     },
-    onError: (error: any) => {
-      toast.error(error.response?.data?.detail?.toString() || 'Failed to delete API key')
+    onError: (error) => {
+      toastApiError(error, 'Failed to delete API key')
     },
   })
 

--- a/src/components/change-password-form.tsx
+++ b/src/components/change-password-form.tsx
@@ -8,11 +8,10 @@ import { useId, useState } from "react";
 import type React from "react";
 import type { JSX } from "react";
 import type { SubmitHandler } from "react-hook-form";
-import type { HttpValidationError } from "@/client";
-import type { AxiosError } from "axios";
 import { Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet"
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
+import { getFormApiErrorMessage } from "@/lib/error-utils";
 import { Input } from "@/components/ui/input";
 import { changePasswordMutation } from "@/client/@tanstack/react-query.gen";
 
@@ -71,10 +70,8 @@ export const ChangePasswordForm: React.FC<ChangePasswordFormProps> = ({
   // Mutation
   const { mutate, isPending } = useMutation({
     ...changePasswordMutation(),
-    onError: (error: AxiosError<HttpValidationError>) => {
-      const message = error.response?.data.detail?.toString()
-        || "An unknown error occurred.";
-      setError("root", { message });
+    onError: (error) => {
+      setError("root", { message: getFormApiErrorMessage(error, "An unknown error occurred.") });
     },
     onSuccess: () => {
       reset();

--- a/src/components/create-project-form.tsx
+++ b/src/components/create-project-form.tsx
@@ -8,11 +8,11 @@ import { useId, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import type { JSX } from "react";
 import type { SubmitHandler } from "react-hook-form";
-import type { HttpValidationError, ProjectPublic } from "@/client"
-import type { AxiosError } from "axios";
+import type { ProjectPublic } from "@/client"
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { getFormApiErrorMessage } from "@/lib/error-utils";
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { createProjectMutation, getProjectsQueryKey } from "@/client/@tanstack/react-query.gen";
 
@@ -98,10 +98,8 @@ export const CreateProjectForm: React.FC<CreateProjectFormProps> = ({ trigger, i
   const queryClient = useQueryClient();
   const { mutate, isPending } = useMutation({
     ...createProjectMutation(),
-    onError: (error: AxiosError<HttpValidationError>) => {
-      const message = error.response?.data.detail?.toString()
-        || "An unknown error occurred.";
-      setError("root", { message });
+    onError: (error) => {
+      setError("root", { message: getFormApiErrorMessage(error, "An unknown error occurred.") });
     },
     onSuccess: (data: ProjectPublic) => {
       reset();

--- a/src/components/error-banner.tsx
+++ b/src/components/error-banner.tsx
@@ -1,0 +1,100 @@
+import { AlertTriangle, ChevronDown, RotateCcw, ServerCrash, WifiOff } from 'lucide-react'
+import { cva } from 'class-variance-authority'
+import { useState } from 'react'
+
+import type { ErrorKind } from '@/lib/error-utils'
+import { cn } from '@/lib/utils'
+import { classifyError, getTechnicalDetail } from '@/lib/error-utils'
+import { Button } from '@/components/ui/button'
+
+const bannerVariants = cva('rounded-lg border p-3', {
+  variants: {
+    kind: {
+      server: 'border-destructive/30 bg-destructive/5',
+      network: 'border-amber-500/30 bg-amber-500/5',
+      client: 'border-border bg-muted/30',
+      unknown: 'border-border bg-muted/30',
+    },
+  },
+  defaultVariants: {
+    kind: 'unknown',
+  },
+})
+
+const iconVariants = cva('h-5 w-5 flex-shrink-0 mt-0.5', {
+  variants: {
+    kind: {
+      server: 'text-destructive',
+      network: 'text-amber-600 dark:text-amber-400',
+      client: 'text-muted-foreground',
+      unknown: 'text-muted-foreground',
+    },
+  },
+  defaultVariants: {
+    kind: 'unknown',
+  },
+})
+
+function iconFor(kind: ErrorKind) {
+  switch (kind) {
+    case 'server':
+      return ServerCrash
+    case 'network':
+      return WifiOff
+    case 'client':
+    case 'unknown':
+    default:
+      return AlertTriangle
+  }
+}
+
+export interface ErrorBannerProps {
+  error: unknown
+  onRetry?: () => void
+  className?: string
+}
+
+export function ErrorBanner({ error, onRetry, className }: ErrorBannerProps) {
+  const info = classifyError(error)
+  const Icon = iconFor(info.kind)
+  const technicalDetail = getTechnicalDetail(error, info)
+  const [detailsOpen, setDetailsOpen] = useState(false)
+
+  return (
+    <div role="alert" className={cn(bannerVariants({ kind: info.kind }), className)}>
+      <div className="flex items-start gap-3">
+        <Icon className={iconVariants({ kind: info.kind })} strokeWidth={2} />
+        <div className="flex-1 min-w-0 space-y-0.5">
+          <p className="text-sm font-medium text-foreground">{info.title}</p>
+          <p className="text-sm text-muted-foreground">{info.description}</p>
+        </div>
+        {onRetry && (
+          <Button size="sm" variant="outline" onClick={onRetry} className="flex-shrink-0">
+            <RotateCcw className="h-3.5 w-3.5" />
+            Retry
+          </Button>
+        )}
+      </div>
+      {technicalDetail && (
+        <div className="pl-8 pt-2">
+          <button
+            type="button"
+            onClick={() => setDetailsOpen((v) => !v)}
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            aria-expanded={detailsOpen}
+          >
+            <ChevronDown
+              className={cn('h-3 w-3 transition-transform', detailsOpen && 'rotate-180')}
+            />
+            {detailsOpen ? 'Hide technical details' : 'Show technical details'}
+          </button>
+          {detailsOpen && (
+            <pre className="mt-2 bg-muted/50 rounded-md p-3 text-left text-xs text-muted-foreground whitespace-pre-wrap break-all max-h-48 overflow-auto">
+              {technicalDetail}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/error-state.tsx
+++ b/src/components/error-state.tsx
@@ -1,0 +1,164 @@
+import { useState } from 'react'
+import { Link } from '@tanstack/react-router'
+import {
+  AlertTriangle,
+  ChevronDown,
+  Home,
+  RotateCcw,
+  ServerCrash,
+  WifiOff,
+} from 'lucide-react'
+import { cva } from 'class-variance-authority'
+
+import type { ErrorKind, FriendlyError } from '@/lib/error-utils'
+import { cn } from '@/lib/utils'
+import { classifyError, getTechnicalDetail } from '@/lib/error-utils'
+import { Button } from '@/components/ui/button'
+import { NGS360Logo } from '@/components/ngs360-logo'
+
+const accentBgVariants = cva('inline-flex items-center justify-center w-16 h-16 rounded-full', {
+  variants: {
+    kind: {
+      server: 'bg-destructive/10',
+      network: 'bg-amber-500/10',
+      client: 'bg-muted',
+      unknown: 'bg-muted',
+    },
+  },
+  defaultVariants: {
+    kind: 'unknown',
+  },
+})
+
+const accentIconVariants = cva('w-8 h-8', {
+  variants: {
+    kind: {
+      server: 'text-destructive',
+      network: 'text-amber-600 dark:text-amber-400',
+      client: 'text-foreground',
+      unknown: 'text-foreground',
+    },
+  },
+  defaultVariants: {
+    kind: 'unknown',
+  },
+})
+
+function iconFor(kind: ErrorKind) {
+  switch (kind) {
+    case 'server':
+      return ServerCrash
+    case 'network':
+      return WifiOff
+    case 'client':
+    case 'unknown':
+    default:
+      return AlertTriangle
+  }
+}
+
+export interface ErrorStateProps {
+  error: unknown
+  onRetry?: () => void
+  friendly?: FriendlyError
+  fullscreen?: boolean
+  className?: string
+}
+
+export function ErrorState({
+  error,
+  onRetry,
+  friendly,
+  fullscreen = false,
+  className,
+}: ErrorStateProps) {
+  const [detailsOpen, setDetailsOpen] = useState(false)
+  const info = friendly ?? classifyError(error)
+  const Icon = iconFor(info.kind)
+
+  const technicalDetail = getTechnicalDetail(error, info)
+
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-center p-6',
+        fullscreen
+          ? 'relative min-h-screen bg-gradient-to-br from-primary/5 via-background to-primary-2/5 overflow-hidden'
+          : 'min-h-[60vh] py-12',
+        className,
+      )}
+    >
+      <div className="relative z-10 w-full max-w-xl text-center space-y-6">
+        {fullscreen && (
+          <div className="flex justify-center mb-4">
+            <NGS360Logo />
+          </div>
+        )}
+
+        <div className={accentBgVariants({ kind: info.kind })}>
+          <Icon className={accentIconVariants({ kind: info.kind })} strokeWidth={2} />
+        </div>
+
+        <div className="space-y-2">
+          <h1
+            className={cn(
+              'font-bold tracking-tight',
+              fullscreen ? 'text-4xl md:text-5xl' : 'text-2xl md:text-3xl',
+            )}
+          >
+            {info.title}
+          </h1>
+          <p className="text-base text-muted-foreground max-w-md mx-auto">
+            {info.description}
+          </p>
+        </div>
+
+        {info.status !== undefined && (
+          <p className="text-xs text-muted-foreground">
+            Error code: <span className="font-mono font-medium">{info.status}</span>
+          </p>
+        )}
+
+        <div className="flex flex-col sm:flex-row gap-3 justify-center pt-2 max-w-sm mx-auto">
+          {onRetry && (
+            <Button onClick={onRetry} className="sm:flex-1">
+              <RotateCcw className="h-4 w-4" />
+              Try Again
+            </Button>
+          )}
+          <Button
+            asChild
+            variant={onRetry ? 'outline' : 'default'}
+            className="sm:flex-1"
+          >
+            <Link to="/">
+              <Home className="h-4 w-4" />
+              Return to Home
+            </Link>
+          </Button>
+        </div>
+
+        {technicalDetail && (
+          <div className="pt-2">
+            <button
+              type="button"
+              onClick={() => setDetailsOpen((v) => !v)}
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              aria-expanded={detailsOpen}
+            >
+              <ChevronDown
+                className={cn('h-3 w-3 transition-transform', detailsOpen && 'rotate-180')}
+              />
+              {detailsOpen ? 'Hide technical details' : 'Show technical details'}
+            </button>
+            {detailsOpen && (
+              <pre className="mt-2 bg-muted/50 rounded-lg p-4 text-left text-xs text-muted-foreground whitespace-pre-wrap break-all max-h-48 overflow-auto max-w-lg mx-auto">
+                {technicalDetail}
+              </pre>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/execute-action-form.tsx
+++ b/src/components/execute-action-form.tsx
@@ -7,6 +7,7 @@ import type { JSX } from 'react'
 import type { ActionOption, ActionPlatform  } from '@/client/types.gen'
 import type { ComboBoxOption } from '@/components/combobox'
 import { ComboBox } from '@/components/combobox'
+import { ErrorBanner } from '@/components/error-banner'
 import { Spinner } from '@/components/spinner'
 import { Stepper } from '@/components/stepper'
 import { Button } from '@/components/ui/button'
@@ -15,6 +16,7 @@ import { Label } from '@/components/ui/label'
 import { Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
 import { getActionOptionsOptions, getActionPlatformsOptions, getActionTypesOptions, submitPipelineJobMutation } from '@/client/@tanstack/react-query.gen'
 import { useInvalidateJobQueries, useViewJob } from '@/hooks/use-job-queries'
+import { toastApiError } from '@/lib/error-utils'
 
 interface ExecuteActionFormProps {
   /** Trigger for the Sheet component */
@@ -132,11 +134,7 @@ export const ExecuteActionForm: React.FC<ExecuteActionFormProps> = ({
       handleReset();
     },
     onError: (error) => {
-      toast.error('Failed to submit pipeline job', {
-        description: (
-          <span className="text-sm text-foreground">{error.message || 'An unexpected error occurred'}</span>
-        ),
-      });
+      toastApiError(error, 'Failed to submit pipeline job')
     },
   });
 
@@ -175,7 +173,12 @@ export const ExecuteActionForm: React.FC<ExecuteActionFormProps> = ({
   }, [projectPlatformsData]);
 
   // Project type options
-  const { data: projectTypesData, isFetching: isLoadingProjectTypes } = useQuery({
+  const {
+    data: projectTypesData,
+    isFetching: isLoadingProjectTypes,
+    error: projectTypesError,
+    refetch: refetchProjectTypes,
+  } = useQuery({
     ...getActionTypesOptions({
       query: {
         action: state.projectAction.value as ActionOption,
@@ -253,6 +256,11 @@ export const ExecuteActionForm: React.FC<ExecuteActionFormProps> = ({
                           <Spinner variant="circle" size={16} />
                           <span>Loading project types...</span>
                         </div>
+                      ) : projectTypesError ? (
+                        <ErrorBanner
+                          error={projectTypesError}
+                          onRetry={() => { void refetchProjectTypes() }}
+                        />
                       ) : (
                         <>
                           <ComboBox

--- a/src/components/execute-demux-job-form.tsx
+++ b/src/components/execute-demux-job-form.tsx
@@ -6,12 +6,12 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 import type { SubmitHandler } from "react-hook-form";
-import type { BatchJobPublic, DemuxWorkflowConfig, HttpValidationError } from "@/client";
-import type { AxiosError } from "axios";
-import { 
+import type { BatchJobPublic, DemuxWorkflowConfig } from "@/client";
+import {
   submitDemultiplexWorkflowJobMutation,
 } from "@/client/@tanstack/react-query.gen";
 import { useInvalidateJobQueries, useViewJob } from "@/hooks/use-job-queries";
+import { toastApiError } from "@/lib/error-utils";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -62,9 +62,9 @@ export const ExecuteToolForm: React.FC<ExecuteToolFormProps> = ({
   // Mutation for submitting workflow
   const { mutate, isPending } = useMutation({
     ...submitDemultiplexWorkflowJobMutation(),
-    onError: (error: AxiosError<HttpValidationError>) => {
+    onError: (error) => {
       console.error("Error submitting workflow execution:", error);
-      toast.error("Failed to execute workflow");
+      toastApiError(error, "Failed to execute workflow");
     },
     onSuccess: (data: BatchJobPublic) => {
       // Invalidate jobs list query to show the new job

--- a/src/components/file-browser.tsx
+++ b/src/components/file-browser.tsx
@@ -7,6 +7,8 @@ import type { FileBrowserFile, FileBrowserFolder } from '@/client/types.gen';
 import { browseS3Options } from '@/client/@tanstack/react-query.gen';
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { ErrorBanner } from "@/components/error-banner";
+import { toastApiError } from "@/lib/error-utils";
 import { SortableHeader } from "@/components/data-table/sortable-header";
 
 // Helper function for formatting bytes
@@ -90,7 +92,7 @@ export const FileBrowser: React.FC<FileBrowserProps> = ({
   };
 
   // Query for file/folder data using browseFilesystem
-  const { data, isLoading, isError, error } = useQuery({
+  const { data, isLoading, isError, error, refetch } = useQuery({
     ...browseS3Options({
       query: {
         uri: currentDirectoryPath
@@ -156,9 +158,7 @@ export const FileBrowser: React.FC<FileBrowserProps> = ({
       // Open in new tab to trigger download
       window.open(url, '_blank');
     } catch (downloadError) {
-      // Display error in alert box
-      const errorMessage = downloadError instanceof Error ? downloadError.message : 'Failed to download file';
-      alert(`Download error: ${errorMessage}`);
+      toastApiError(downloadError, 'Failed to download file');
     }
   };
 
@@ -208,7 +208,7 @@ export const FileBrowser: React.FC<FileBrowserProps> = ({
   ];
 
   if (isError) {
-    return <div className="p-4 text-center text-destructive">Error: {error.message || 'Failed to load directory.'}</div>;
+    return <ErrorBanner error={error} onRetry={() => { void refetch() }} className="m-4" />;
   }
 
   return (

--- a/src/components/forgot-password-form.tsx
+++ b/src/components/forgot-password-form.tsx
@@ -21,6 +21,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
+import { getFormApiErrorMessage } from '@/lib/error-utils'
 import { requestPasswordResetMutation } from '@/client/@tanstack/react-query.gen'
 import { NGS360Logo } from '@/components/ngs360-logo'
 
@@ -53,9 +54,7 @@ export function ForgotPasswordForm({
   const { mutate, isPending } = useMutation({
     ...requestPasswordResetMutation(),
     onError: (error) => {
-      const message =
-        error.response?.data.detail?.toString() || 'An unknown error occurred.'
-      setError('root', { message })
+      setError('root', { message: getFormApiErrorMessage(error, 'An unknown error occurred.') })
     },
     onSuccess: (_, variables) => {
       toast.success('Password reset email sent. Please check your inbox.')

--- a/src/components/login-form-default.tsx
+++ b/src/components/login-form-default.tsx
@@ -14,6 +14,7 @@ import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
 import { cn } from '@/lib/utils'
+import { getFormApiErrorMessage } from '@/lib/error-utils'
 import { NGS360Logo } from '@/components/ngs360-logo'
 import { useAuth } from '@/context/auth-context'
 import { resolvePostLoginRedirect } from '@/lib/post-login-redirect'
@@ -64,9 +65,8 @@ export function LoginFormDefault({
       await basicLogin(data.username, data.password)
       toast.success('Login successful')
       window.location.assign(resolvePostLoginRedirect(redirectTo))
-    } catch (error: any) {
-      const message = error?.message || 'An unknown error occurred.'
-      setError('root', { message })
+    } catch (error) {
+      setError('root', { message: getFormApiErrorMessage(error, 'An unknown error occurred.') })
     } finally {
       setIsLoading(false)
     }

--- a/src/components/register-form.tsx
+++ b/src/components/register-form.tsx
@@ -13,6 +13,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
+import { getFormApiErrorMessage } from '@/lib/error-utils'
 import { registerMutation } from '@/client/@tanstack/react-query.gen'
 import { NGS360Logo } from '@/components/ngs360-logo'
 import { RegisterSuccessDialog } from '@/components/register-success-dialog'
@@ -52,9 +53,7 @@ export function RegisterForm({
   const { mutate, isPending } = useMutation({
     ...registerMutation(),
     onError: (error) => {
-      const message =
-        error.response?.data.detail?.toString() || 'An unknown error occurred.'
-      setError('root', { message })
+      setError('root', { message: getFormApiErrorMessage(error, 'An unknown error occurred.') })
     },
     onSuccess: (_data: UserPublic, variables: { body: UserRegister }) => {
       setEmail(variables.body.email)

--- a/src/components/register-success-dialog.tsx
+++ b/src/components/register-success-dialog.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { loginMutation } from '@/client/@tanstack/react-query.gen'
+import { toastApiError } from '@/lib/error-utils'
 
 interface RegisterSuccessDialogProps {
   open: boolean
@@ -30,9 +31,7 @@ export function RegisterSuccessDialog({
   const { mutate } = useMutation({
     ...loginMutation(),
     onError: (error) => {
-      const message =
-        error.response?.data.detail?.toString() || 'An unknown error occurred.'
-      toast.error(message)
+      toastApiError(error, 'An unknown error occurred.')
     },
     onSuccess: () => {
       toast.success('Login successful')

--- a/src/components/reset-password-form.tsx
+++ b/src/components/reset-password-form.tsx
@@ -12,6 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
+import { getFormApiErrorMessage } from '@/lib/error-utils'
 import { confirmPasswordResetMutation } from '@/client/@tanstack/react-query.gen'
 import { NGS360Logo } from '@/components/ngs360-logo'
 
@@ -57,9 +58,10 @@ export function ResetPasswordForm({
   const { mutate, isPending, isSuccess, isError, error } = useMutation({
     ...confirmPasswordResetMutation(),
     onError: (err) => {
-      const message =
-        err.response?.data.detail?.toString() || 
-        'The reset token is invalid or has expired. Please request a new password reset.'
+      const message = getFormApiErrorMessage(
+        err,
+        'The reset token is invalid or has expired. Please request a new password reset.',
+      )
       setError('root', { message })
       toast.error(message)
     },
@@ -115,8 +117,7 @@ export function ResetPasswordForm({
             <div>
               <h3 className="text-lg font-semibold mb-2">Reset Failed</h3>
               <p className="text-muted-foreground">
-                {error.response?.data.detail?.toString() || 
-                 'The reset token is invalid or has expired. Please request a new password reset.'}
+                {getFormApiErrorMessage(error, 'The reset token is invalid or has expired. Please request a new password reset.')}
               </p>
             </div>
             <Button 

--- a/src/components/samplesheet-not-found-component.tsx
+++ b/src/components/samplesheet-not-found-component.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { FullscreenSpinner } from "@/components/spinner";
 import { FileUpload } from "@/components/file-upload"
 import { getRunSamplesheetQueryKey, postRunSamplesheetMutation } from "@/client/@tanstack/react-query.gen";
+import { toastApiError } from "@/lib/error-utils";
 
 // Define error component for samplesheet path
 export const NotFoundComponent = () => {
@@ -31,6 +32,7 @@ export const NotFoundComponent = () => {
     },
     onError: (error) => {
       console.error(error);
+      toastApiError(error, 'Failed to upload samplesheet');
     }
   })
 

--- a/src/components/search-bar.tsx
+++ b/src/components/search-bar.tsx
@@ -12,6 +12,7 @@ import { searchOptions } from '@/client/@tanstack/react-query.gen'
 import { useDebounce } from '@/hooks/use-debounce'
 import { Separator } from '@/components/ui/separator'
 import { highlightMatch } from '@/lib/utils'
+import { ErrorBanner } from '@/components/error-banner'
 
 // Search item component
 interface SearchItemProps {
@@ -78,8 +79,10 @@ export const SearchBar: FC<SearchBarProps> = ({ onResultClick, idPrefix }) => {
   };
 
   // Query using debounced input
-  const { 
-    data: { projects, runs } = { projects: [], runs: [] }
+  const {
+    data: { projects, runs } = { projects: [], runs: [] },
+    error,
+    refetch,
   } = useQuery({
     ...searchOptions({
       query: {
@@ -91,7 +94,8 @@ export const SearchBar: FC<SearchBarProps> = ({ onResultClick, idPrefix }) => {
       projects: res.projects.data,
       runs: res.runs.data
     }),
-    enabled: !!debouncedInput
+    enabled: !!debouncedInput,
+    retry: false,
   })
 
   // Trigger popover when debouncedInput changes
@@ -274,7 +278,15 @@ export const SearchBar: FC<SearchBarProps> = ({ onResultClick, idPrefix }) => {
                 </SearchGroup>
               )}
 
-              {projects.length === 0 && runs.length === 0 && (
+              {error && (
+                <ErrorBanner
+                  error={error}
+                  onRetry={() => { void refetch() }}
+                  className="m-2"
+                />
+              )}
+
+              {!error && projects.length === 0 && runs.length === 0 && (
                 <div className="flex justify-center p-4 text-sm text-muted-foreground">
                   No results found.
                 </div>

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -9,11 +9,15 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={theme as ToasterProps["theme"]}
       className="toaster group"
+      richColors
       style={
         {
           "--normal-bg": "var(--popover)",
           "--normal-text": "var(--popover-foreground)",
           "--normal-border": "var(--border)",
+          "--error-bg": "var(--popover)",
+          "--error-text": "var(--destructive)",
+          "--error-border": "color-mix(in oklab, var(--destructive) 30%, transparent)",
         } as React.CSSProperties
       }
       {...props}

--- a/src/components/update-project-form.tsx
+++ b/src/components/update-project-form.tsx
@@ -7,11 +7,11 @@ import { toast } from 'sonner';
 import { useId, useState } from "react";
 import type { JSX } from "react";
 import type { SubmitHandler } from "react-hook-form";
-import type { HttpValidationError, ProjectPublic } from "@/client"
-import type { AxiosError } from "axios";
+import type { ProjectPublic } from "@/client"
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { getFormApiErrorMessage } from "@/lib/error-utils";
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { getProjectByProjectIdQueryKey, getProjectSamplesQueryKey, getProjectsQueryKey, updateProjectMutation } from "@/client/@tanstack/react-query.gen";
 
@@ -103,10 +103,8 @@ export const UpdateProjectForm: React.FC<UpdateProjectFormProps> = ({
   const queryClient = useQueryClient();
   const { mutate, isPending } = useMutation({
     ...updateProjectMutation(),
-    onError: (error: AxiosError<HttpValidationError>) => {
-      const message = error.response?.data.detail?.toString()
-        || "An unknown error occurred.";
-      setError("root", { message });
+    onError: (error) => {
+      setError("root", { message: getFormApiErrorMessage(error, "An unknown error occurred.") });
     },
     onSuccess: (data: ProjectPublic) => {
       reset({

--- a/src/components/update-vendor-form.tsx
+++ b/src/components/update-vendor-form.tsx
@@ -8,11 +8,11 @@ import { useState } from "react";
 import type React from "react";
 import type { JSX } from "react";
 import type { SubmitHandler } from "react-hook-form";
-import type { HttpValidationError, VendorPublic } from "@/client";
-import type { AxiosError } from "axios";
+import type { VendorPublic } from "@/client";
 import { Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet"
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
+import { getFormApiErrorMessage } from "@/lib/error-utils";
 import { Input } from "@/components/ui/input";
 import { getVendorsQueryKey, updateVendorMutation } from "@/client/@tanstack/react-query.gen";
 import { Textarea } from "@/components/ui/textarea";
@@ -69,10 +69,8 @@ export const UpdateVendorForm: React.FC<UpdateVendorFormProps> = ({
   const queryClient = useQueryClient();
   const { mutate, isPending } = useMutation({
     ...updateVendorMutation(),
-    onError: (error: AxiosError<HttpValidationError>) => {
-      const message = error.response?.data.detail?.toString()
-        || "An unknown error occurred.";
-      setError("root", { message });
+    onError: (error) => {
+      setError("root", { message: getFormApiErrorMessage(error, "An unknown error occurred.") });
     },
     onSuccess: (data: VendorPublic) => {
       reset();

--- a/src/components/validate-manifest-form.tsx
+++ b/src/components/validate-manifest-form.tsx
@@ -18,6 +18,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { toastApiError } from '@/lib/error-utils'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -181,7 +182,8 @@ export const ValidateManifestForm: React.FC<ValidateManifestFormProps> = ({
       getLatestManifest({
         query: {
           s3_path: `${state.selectedVendor.value}/${projectId}/`
-        }
+        },
+        throwOnError: true,
       }).then((response) => {
         // Check if response has status 204 (no content)
         if (response.status === 204) {
@@ -193,7 +195,8 @@ export const ValidateManifestForm: React.FC<ValidateManifestFormProps> = ({
         }
         dispatch({ type: 'SET_IS_LOADING_MANIFEST', value: false });
       }).catch((error) => {
-        alert(`Error fetching latest manifest: ${error.message || 'Unknown error'}`);
+        toastApiError(error, 'Failed to fetch latest manifest');
+        dispatch({ type: 'SET_LATEST_MANIFEST_PATH', value: 'Could not load the latest manifest' });
         dispatch({ type: 'SET_MANIFEST_ERROR', value: true });
         dispatch({ type: 'SET_IS_LOADING_MANIFEST', value: false });
       });
@@ -218,7 +221,7 @@ export const ValidateManifestForm: React.FC<ValidateManifestFormProps> = ({
           toast.success('Manifest uploaded successfully');
         },
         onError: (error) => {
-          toast.error(`Error uploading manifest: ${error.message || 'Unknown error'}`);
+          toastApiError(error, 'Error uploading manifest');
           console.error(error);
         }
       });
@@ -252,7 +255,7 @@ export const ValidateManifestForm: React.FC<ValidateManifestFormProps> = ({
       }
     },
     onError: (error) => {
-      toast.error(`Error uploading manifest: ${error.message || 'Unknown error'}`);
+      toastApiError(error, 'Error validating manifest');
       console.error(error);
     }
   });
@@ -293,11 +296,7 @@ export const ValidateManifestForm: React.FC<ValidateManifestFormProps> = ({
       }, 700);
     },
     onError: (error) => {
-      toast.error('Failed to submit ingest job', {
-        description: (
-          <span className="text-sm text-foreground">{error.message || 'An unexpected error occurred'}</span>
-        ),
-      });
+      toastApiError(error, 'Failed to submit ingest job');
       console.error(error);
     }
   });

--- a/src/integrations/tanstack-query/root-provider.tsx
+++ b/src/integrations/tanstack-query/root-provider.tsx
@@ -1,6 +1,13 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // Only retry once on failure so errors surface quickly in the UI.
+      retry: 1,
+    },
+  },
+})
 
 export function getContext() {
   return {

--- a/src/lib/error-utils.ts
+++ b/src/lib/error-utils.ts
@@ -1,0 +1,206 @@
+import { AxiosError } from 'axios'
+import { toast } from 'sonner'
+
+export type ErrorKind = 'server' | 'network' | 'client' | 'unknown'
+
+export interface FriendlyError {
+  kind: ErrorKind
+  status?: number
+  title: string
+  description: string
+  detail?: string
+}
+
+function extractDetail(err: AxiosError<{ detail?: unknown } | undefined>): string | undefined {
+  const raw = err.response?.data?.detail
+  if (typeof raw === 'string' && raw.trim()) return raw
+  if (Array.isArray(raw) && raw.length > 0) {
+    const first = raw[0] as { msg?: string } | string | undefined
+    if (typeof first === 'string') return first
+    if (first && typeof first === 'object' && typeof first.msg === 'string') return first.msg
+  }
+  return undefined
+}
+
+function specificFriendlyError(status: number, detail: string | undefined): FriendlyError | undefined {
+  switch (status) {
+    case 400:
+      return {
+        kind: 'client',
+        status,
+        title: "That request wasn't accepted",
+        description:
+          detail ?? "The server couldn't process this request. Please review your input and try again.",
+        detail,
+      }
+    case 401:
+      return {
+        kind: 'client',
+        status,
+        title: 'Your session has expired',
+        description: detail ?? 'Please sign in again to continue.',
+        detail,
+      }
+    case 403:
+      return {
+        kind: 'client',
+        status,
+        title: "You don't have access to this",
+        description:
+          detail ??
+          "Your account doesn't have permission for this action. If you believe this is a mistake, please contact a system administrator or support.",
+        detail,
+      }
+    case 404:
+      return {
+        kind: 'client',
+        status,
+        title: "We couldn't find that",
+        description:
+          detail ?? "The item you're looking for may have been moved, renamed, or deleted.",
+        detail,
+      }
+    case 409:
+      return {
+        kind: 'client',
+        status,
+        title: 'This conflicts with existing data',
+        description:
+          detail ??
+          'Another record already exists with these details, or the item was changed by someone else. Refresh and try again.',
+        detail,
+      }
+    case 422:
+      return {
+        kind: 'client',
+        status,
+        title: 'Some fields need attention',
+        description: detail ?? 'Please review the highlighted fields and try again.',
+        detail,
+      }
+    case 429:
+      return {
+        kind: 'client',
+        status,
+        title: "You're doing that too fast",
+        description: detail ?? 'Please wait a moment and try again.',
+        detail,
+      }
+    case 502:
+    case 503:
+    case 504:
+      return {
+        kind: 'server',
+        status,
+        title: 'The service is temporarily unavailable',
+        description:
+          detail ??
+          'Our servers are taking longer than usual to respond. Please try again in a few moments. If the problem persists, contact support.',
+        detail,
+      }
+    default:
+      return undefined
+  }
+}
+
+export function classifyError(error: unknown): FriendlyError {
+  if (error instanceof AxiosError) {
+    const status = error.response?.status
+    const detail = extractDetail(error as AxiosError<{ detail?: unknown }>)
+
+    if (!error.response) {
+      return {
+        kind: 'network',
+        title: "We couldn't reach the server",
+        description:
+          'Check your internet connection and try again. If the problem persists, the service may be briefly offline.',
+      }
+    }
+
+    if (status !== undefined) {
+      const specific = specificFriendlyError(status, detail)
+      if (specific) return specific
+    }
+
+    if (status !== undefined && status >= 500) {
+      return {
+        kind: 'server',
+        status,
+        title: 'Our servers ran into a problem',
+        description:
+          "This isn't your fault. Something went wrong on our end — we've been notified and are looking into it. Please try again in a moment.",
+        detail,
+      }
+    }
+
+    if (status !== undefined && status >= 400) {
+      return {
+        kind: 'client',
+        status,
+        title: 'The request could not be completed',
+        description: detail ?? 'The server rejected the request. Please review your input and try again.',
+        detail,
+      }
+    }
+  }
+
+  const message = error instanceof Error ? error.message : undefined
+  return {
+    kind: 'unknown',
+    title: 'Something went wrong',
+    description:
+      message ?? 'An unexpected error occurred. Please try again, or reload the page if the problem continues.',
+    detail: message,
+  }
+}
+
+export function isServerError(error: unknown): boolean {
+  return error instanceof AxiosError && (error.response?.status ?? 0) >= 500
+}
+
+/**
+ * Describe an error for the "Show technical details" panel in a way that's
+ * useful to forward to a support person. Prefers the backend's `detail`
+ * message; for AxiosErrors with no detail, describes the HTTP exchange
+ * (method, URL, status) rather than the JS stack — so a 503 reads as a
+ * backend problem, not an "AxiosError". Falls back to stack/message for
+ * non-Axios errors.
+ */
+export function getTechnicalDetail(error: unknown, info: FriendlyError): string {
+  if (info.detail) return info.detail
+  if (error instanceof AxiosError) {
+    const method = error.config?.method?.toUpperCase() ?? 'REQUEST'
+    const url = error.config?.url ?? '(unknown URL)'
+    if (error.response) {
+      const statusText = error.response.statusText || ''
+      return `HTTP ${error.response.status} ${statusText}`.trim() + ` from ${method} ${url}\nThe server did not provide additional details.`
+    }
+    return `${method} ${url}\nNo response from server: ${error.message}`
+  }
+  if (error instanceof Error) return error.stack ?? error.message
+  return String(error)
+}
+
+/**
+ * Show a friendly error toast. For 5xx/network errors, uses the generic
+ * friendly text; for 4xx, prefers the server's `detail` message; otherwise
+ * falls back to the caller-supplied title (e.g. "Failed to create API key").
+ */
+export function toastApiError(error: unknown, fallbackTitle: string): void {
+  const info = classifyError(error)
+  if (info.kind === 'server' || info.kind === 'network') {
+    toast.error(info.title, { description: info.description })
+    return
+  }
+  toast.error(info.detail ?? fallbackTitle)
+}
+
+/**
+ * Return a single-line error message suitable for inline form display
+ * (e.g. react-hook-form's `setError('root', { message })`).
+ */
+export function getFormApiErrorMessage(error: unknown, fallbackTitle: string): string {
+  const info = classifyError(error)
+  if (info.kind === 'server' || info.kind === 'network') return info.description
+  return info.detail ?? fallbackTitle
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,6 +14,13 @@ import reportWebVitals from './reportWebVitals.ts'
 // Import client interceptors
 // These add auth tokens to all requests
 import '@/lib/interceptors.ts';
+import type { ErrorComponentProps } from '@tanstack/react-router'
+import { ErrorState } from '@/components/error-state'
+
+
+function DefaultErrorComponent({ error, reset }: ErrorComponentProps) {
+  return <ErrorState error={error} onRetry={reset} />
+}
 
 // Create a new router instance
 const router = createRouter({
@@ -26,6 +33,7 @@ const router = createRouter({
   scrollRestoration: true,
   defaultStructuralSharing: true,
   defaultPreloadStaleTime: 0,
+  defaultErrorComponent: DefaultErrorComponent,
 })
 
 // Register the router instance for type safety

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -8,731 +8,560 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as AuthRouteImport } from './routes/_auth'
-import { Route as UserRouteRouteImport } from './routes/_user.route'
-import { Route as AuthIndexRouteImport } from './routes/_auth.index'
-import { Route as UserVerifyEmailRouteImport } from './routes/_user.verify-email'
-import { Route as UserResetPasswordRouteImport } from './routes/_user.reset-password'
-import { Route as AuthRunsRouteRouteImport } from './routes/_auth.runs.route'
-import { Route as AuthProjectsRouteRouteImport } from './routes/_auth.projects.route'
-import { Route as AuthProfileRouteRouteImport } from './routes/_auth.profile.route'
-import { Route as AuthJobsRouteRouteImport } from './routes/_auth.jobs.route'
-import { Route as AuthAdminRouteRouteImport } from './routes/_auth.admin.route'
-import { Route as UserRegisterIndexRouteImport } from './routes/_user.register.index'
-import { Route as UserLoginIndexRouteImport } from './routes/_user.login.index'
-import { Route as UserForgotPasswordIndexRouteImport } from './routes/_user.forgot-password.index'
-import { Route as UserAccessDeniedIndexRouteImport } from './routes/_user.access-denied.index'
-import { Route as AuthRunsIndexRouteImport } from './routes/_auth.runs.index'
-import { Route as AuthProjectsIndexRouteImport } from './routes/_auth.projects.index'
-import { Route as AuthProfileIndexRouteImport } from './routes/_auth.profile.index'
-import { Route as AuthJobsIndexRouteImport } from './routes/_auth.jobs.index'
-import { Route as AuthAdminIndexRouteImport } from './routes/_auth.admin.index'
-import { Route as AuthRunsRun_barcodeRouteRouteImport } from './routes/_auth.runs.$run_barcode.route'
-import { Route as AuthProjectsProject_idRouteRouteImport } from './routes/_auth.projects.$project_id.route'
-import { Route as AuthJobsJob_idRouteRouteImport } from './routes/_auth.jobs.$job_id.route'
-import { Route as AuthAdminVendorsRouteRouteImport } from './routes/_auth.admin.vendors.route'
-import { Route as AuthAdminRunSettingsRouteRouteImport } from './routes/_auth.admin.run-settings.route'
-import { Route as AuthAdminProjectSettingsRouteRouteImport } from './routes/_auth.admin.project-settings.route'
-import { Route as AuthAdminJobsRouteRouteImport } from './routes/_auth.admin.jobs.route'
-import { Route as AuthRunsRun_barcodeIndexRouteImport } from './routes/_auth.runs.$run_barcode.index'
-import { Route as AuthProjectsProject_idIndexRouteImport } from './routes/_auth.projects.$project_id.index'
-import { Route as AuthJobsJob_idIndexRouteImport } from './routes/_auth.jobs.$job_id.index'
-import { Route as AuthAdminVendorsIndexRouteImport } from './routes/_auth.admin.vendors.index'
-import { Route as AuthAdminRunSettingsIndexRouteImport } from './routes/_auth.admin.run-settings.index'
-import { Route as AuthAdminProjectSettingsIndexRouteImport } from './routes/_auth.admin.project-settings.index'
-import { Route as AuthAdminJobsIndexRouteImport } from './routes/_auth.admin.jobs.index'
-import { Route as UserOauthProviderCallbackRouteImport } from './routes/_user.oauth.$provider.callback'
-import { Route as AuthRunsRun_barcodeSamplesheetRouteRouteImport } from './routes/_auth.runs.$run_barcode.samplesheet.route'
-import { Route as AuthRunsRun_barcodeIndexqcRouteRouteImport } from './routes/_auth.runs.$run_barcode.indexqc.route'
-import { Route as AuthRunsRun_barcodeSamplesheetIndexRouteImport } from './routes/_auth.runs.$run_barcode.samplesheet.index'
-import { Route as AuthRunsRun_barcodeIndexqcIndexRouteImport } from './routes/_auth.runs.$run_barcode.indexqc.index'
+// Import Routes
 
-const AuthRoute = AuthRouteImport.update({
+import { Route as rootRoute } from './routes/__root'
+import { Route as AuthImport } from './routes/_auth'
+import { Route as UserRouteImport } from './routes/_user.route'
+import { Route as AuthIndexImport } from './routes/_auth.index'
+import { Route as UserVerifyEmailImport } from './routes/_user.verify-email'
+import { Route as UserResetPasswordImport } from './routes/_user.reset-password'
+import { Route as AuthRunsRouteImport } from './routes/_auth.runs.route'
+import { Route as AuthProjectsRouteImport } from './routes/_auth.projects.route'
+import { Route as AuthProfileRouteImport } from './routes/_auth.profile.route'
+import { Route as AuthJobsRouteImport } from './routes/_auth.jobs.route'
+import { Route as AuthAdminRouteImport } from './routes/_auth.admin.route'
+import { Route as UserRegisterIndexImport } from './routes/_user.register.index'
+import { Route as UserLoginIndexImport } from './routes/_user.login.index'
+import { Route as UserForgotPasswordIndexImport } from './routes/_user.forgot-password.index'
+import { Route as UserAccessDeniedIndexImport } from './routes/_user.access-denied.index'
+import { Route as AuthRunsIndexImport } from './routes/_auth.runs.index'
+import { Route as AuthProjectsIndexImport } from './routes/_auth.projects.index'
+import { Route as AuthProfileIndexImport } from './routes/_auth.profile.index'
+import { Route as AuthJobsIndexImport } from './routes/_auth.jobs.index'
+import { Route as AuthAdminIndexImport } from './routes/_auth.admin.index'
+import { Route as AuthRunsRunbarcodeRouteImport } from './routes/_auth.runs.$run_barcode.route'
+import { Route as AuthProjectsProjectidRouteImport } from './routes/_auth.projects.$project_id.route'
+import { Route as AuthJobsJobidRouteImport } from './routes/_auth.jobs.$job_id.route'
+import { Route as AuthAdminVendorsRouteImport } from './routes/_auth.admin.vendors.route'
+import { Route as AuthAdminRunSettingsRouteImport } from './routes/_auth.admin.run-settings.route'
+import { Route as AuthAdminProjectSettingsRouteImport } from './routes/_auth.admin.project-settings.route'
+import { Route as AuthAdminJobsRouteImport } from './routes/_auth.admin.jobs.route'
+import { Route as AuthRunsRunbarcodeIndexImport } from './routes/_auth.runs.$run_barcode.index'
+import { Route as AuthProjectsProjectidIndexImport } from './routes/_auth.projects.$project_id.index'
+import { Route as AuthJobsJobidIndexImport } from './routes/_auth.jobs.$job_id.index'
+import { Route as AuthAdminVendorsIndexImport } from './routes/_auth.admin.vendors.index'
+import { Route as AuthAdminRunSettingsIndexImport } from './routes/_auth.admin.run-settings.index'
+import { Route as AuthAdminProjectSettingsIndexImport } from './routes/_auth.admin.project-settings.index'
+import { Route as AuthAdminJobsIndexImport } from './routes/_auth.admin.jobs.index'
+import { Route as UserOauthProviderCallbackImport } from './routes/_user.oauth.$provider.callback'
+import { Route as AuthRunsRunbarcodeSamplesheetRouteImport } from './routes/_auth.runs.$run_barcode.samplesheet.route'
+import { Route as AuthRunsRunbarcodeIndexqcRouteImport } from './routes/_auth.runs.$run_barcode.indexqc.route'
+import { Route as AuthRunsRunbarcodeSamplesheetIndexImport } from './routes/_auth.runs.$run_barcode.samplesheet.index'
+import { Route as AuthRunsRunbarcodeIndexqcIndexImport } from './routes/_auth.runs.$run_barcode.indexqc.index'
+
+// Create/Update Routes
+
+const AuthRoute = AuthImport.update({
   id: '/_auth',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const UserRouteRoute = UserRouteRouteImport.update({
+
+const UserRouteRoute = UserRouteImport.update({
   id: '/_user',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const AuthIndexRoute = AuthIndexRouteImport.update({
+
+const AuthIndexRoute = AuthIndexImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AuthRoute,
 } as any)
-const UserVerifyEmailRoute = UserVerifyEmailRouteImport.update({
+
+const UserVerifyEmailRoute = UserVerifyEmailImport.update({
   id: '/verify-email',
   path: '/verify-email',
   getParentRoute: () => UserRouteRoute,
 } as any)
-const UserResetPasswordRoute = UserResetPasswordRouteImport.update({
+
+const UserResetPasswordRoute = UserResetPasswordImport.update({
   id: '/reset-password',
   path: '/reset-password',
   getParentRoute: () => UserRouteRoute,
 } as any)
-const AuthRunsRouteRoute = AuthRunsRouteRouteImport.update({
+
+const AuthRunsRouteRoute = AuthRunsRouteImport.update({
   id: '/runs',
   path: '/runs',
   getParentRoute: () => AuthRoute,
 } as any)
-const AuthProjectsRouteRoute = AuthProjectsRouteRouteImport.update({
+
+const AuthProjectsRouteRoute = AuthProjectsRouteImport.update({
   id: '/projects',
   path: '/projects',
   getParentRoute: () => AuthRoute,
 } as any)
-const AuthProfileRouteRoute = AuthProfileRouteRouteImport.update({
+
+const AuthProfileRouteRoute = AuthProfileRouteImport.update({
   id: '/profile',
   path: '/profile',
   getParentRoute: () => AuthRoute,
 } as any)
-const AuthJobsRouteRoute = AuthJobsRouteRouteImport.update({
+
+const AuthJobsRouteRoute = AuthJobsRouteImport.update({
   id: '/jobs',
   path: '/jobs',
   getParentRoute: () => AuthRoute,
 } as any)
-const AuthAdminRouteRoute = AuthAdminRouteRouteImport.update({
+
+const AuthAdminRouteRoute = AuthAdminRouteImport.update({
   id: '/admin',
   path: '/admin',
   getParentRoute: () => AuthRoute,
 } as any)
-const UserRegisterIndexRoute = UserRegisterIndexRouteImport.update({
+
+const UserRegisterIndexRoute = UserRegisterIndexImport.update({
   id: '/register/',
   path: '/register/',
   getParentRoute: () => UserRouteRoute,
 } as any)
-const UserLoginIndexRoute = UserLoginIndexRouteImport.update({
+
+const UserLoginIndexRoute = UserLoginIndexImport.update({
   id: '/login/',
   path: '/login/',
   getParentRoute: () => UserRouteRoute,
 } as any)
-const UserForgotPasswordIndexRoute = UserForgotPasswordIndexRouteImport.update({
+
+const UserForgotPasswordIndexRoute = UserForgotPasswordIndexImport.update({
   id: '/forgot-password/',
   path: '/forgot-password/',
   getParentRoute: () => UserRouteRoute,
 } as any)
-const UserAccessDeniedIndexRoute = UserAccessDeniedIndexRouteImport.update({
+
+const UserAccessDeniedIndexRoute = UserAccessDeniedIndexImport.update({
   id: '/access-denied/',
   path: '/access-denied/',
   getParentRoute: () => UserRouteRoute,
 } as any)
-const AuthRunsIndexRoute = AuthRunsIndexRouteImport.update({
+
+const AuthRunsIndexRoute = AuthRunsIndexImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AuthRunsRouteRoute,
 } as any)
-const AuthProjectsIndexRoute = AuthProjectsIndexRouteImport.update({
+
+const AuthProjectsIndexRoute = AuthProjectsIndexImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AuthProjectsRouteRoute,
 } as any)
-const AuthProfileIndexRoute = AuthProfileIndexRouteImport.update({
+
+const AuthProfileIndexRoute = AuthProfileIndexImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AuthProfileRouteRoute,
 } as any)
-const AuthJobsIndexRoute = AuthJobsIndexRouteImport.update({
+
+const AuthJobsIndexRoute = AuthJobsIndexImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AuthJobsRouteRoute,
 } as any)
-const AuthAdminIndexRoute = AuthAdminIndexRouteImport.update({
+
+const AuthAdminIndexRoute = AuthAdminIndexImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AuthAdminRouteRoute,
 } as any)
-const AuthRunsRun_barcodeRouteRoute =
-  AuthRunsRun_barcodeRouteRouteImport.update({
-    id: '/$run_barcode',
-    path: '/$run_barcode',
-    getParentRoute: () => AuthRunsRouteRoute,
-  } as any)
-const AuthProjectsProject_idRouteRoute =
-  AuthProjectsProject_idRouteRouteImport.update({
+
+const AuthRunsRunbarcodeRouteRoute = AuthRunsRunbarcodeRouteImport.update({
+  id: '/$run_barcode',
+  path: '/$run_barcode',
+  getParentRoute: () => AuthRunsRouteRoute,
+} as any)
+
+const AuthProjectsProjectidRouteRoute = AuthProjectsProjectidRouteImport.update(
+  {
     id: '/$project_id',
     path: '/$project_id',
     getParentRoute: () => AuthProjectsRouteRoute,
-  } as any)
-const AuthJobsJob_idRouteRoute = AuthJobsJob_idRouteRouteImport.update({
+  } as any,
+)
+
+const AuthJobsJobidRouteRoute = AuthJobsJobidRouteImport.update({
   id: '/$job_id',
   path: '/$job_id',
   getParentRoute: () => AuthJobsRouteRoute,
 } as any)
-const AuthAdminVendorsRouteRoute = AuthAdminVendorsRouteRouteImport.update({
+
+const AuthAdminVendorsRouteRoute = AuthAdminVendorsRouteImport.update({
   id: '/vendors',
   path: '/vendors',
   getParentRoute: () => AuthAdminRouteRoute,
 } as any)
-const AuthAdminRunSettingsRouteRoute =
-  AuthAdminRunSettingsRouteRouteImport.update({
-    id: '/run-settings',
-    path: '/run-settings',
-    getParentRoute: () => AuthAdminRouteRoute,
-  } as any)
+
+const AuthAdminRunSettingsRouteRoute = AuthAdminRunSettingsRouteImport.update({
+  id: '/run-settings',
+  path: '/run-settings',
+  getParentRoute: () => AuthAdminRouteRoute,
+} as any)
+
 const AuthAdminProjectSettingsRouteRoute =
-  AuthAdminProjectSettingsRouteRouteImport.update({
+  AuthAdminProjectSettingsRouteImport.update({
     id: '/project-settings',
     path: '/project-settings',
     getParentRoute: () => AuthAdminRouteRoute,
   } as any)
-const AuthAdminJobsRouteRoute = AuthAdminJobsRouteRouteImport.update({
+
+const AuthAdminJobsRouteRoute = AuthAdminJobsRouteImport.update({
   id: '/jobs',
   path: '/jobs',
   getParentRoute: () => AuthAdminRouteRoute,
 } as any)
-const AuthRunsRun_barcodeIndexRoute =
-  AuthRunsRun_barcodeIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => AuthRunsRun_barcodeRouteRoute,
-  } as any)
-const AuthProjectsProject_idIndexRoute =
-  AuthProjectsProject_idIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => AuthProjectsProject_idRouteRoute,
-  } as any)
-const AuthJobsJob_idIndexRoute = AuthJobsJob_idIndexRouteImport.update({
+
+const AuthRunsRunbarcodeIndexRoute = AuthRunsRunbarcodeIndexImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => AuthJobsJob_idRouteRoute,
+  getParentRoute: () => AuthRunsRunbarcodeRouteRoute,
 } as any)
-const AuthAdminVendorsIndexRoute = AuthAdminVendorsIndexRouteImport.update({
+
+const AuthProjectsProjectidIndexRoute = AuthProjectsProjectidIndexImport.update(
+  {
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthProjectsProjectidRouteRoute,
+  } as any,
+)
+
+const AuthJobsJobidIndexRoute = AuthJobsJobidIndexImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AuthJobsJobidRouteRoute,
+} as any)
+
+const AuthAdminVendorsIndexRoute = AuthAdminVendorsIndexImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AuthAdminVendorsRouteRoute,
 } as any)
-const AuthAdminRunSettingsIndexRoute =
-  AuthAdminRunSettingsIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => AuthAdminRunSettingsRouteRoute,
-  } as any)
+
+const AuthAdminRunSettingsIndexRoute = AuthAdminRunSettingsIndexImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AuthAdminRunSettingsRouteRoute,
+} as any)
+
 const AuthAdminProjectSettingsIndexRoute =
-  AuthAdminProjectSettingsIndexRouteImport.update({
+  AuthAdminProjectSettingsIndexImport.update({
     id: '/',
     path: '/',
     getParentRoute: () => AuthAdminProjectSettingsRouteRoute,
   } as any)
-const AuthAdminJobsIndexRoute = AuthAdminJobsIndexRouteImport.update({
+
+const AuthAdminJobsIndexRoute = AuthAdminJobsIndexImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AuthAdminJobsRouteRoute,
 } as any)
-const UserOauthProviderCallbackRoute =
-  UserOauthProviderCallbackRouteImport.update({
-    id: '/oauth/$provider/callback',
-    path: '/oauth/$provider/callback',
-    getParentRoute: () => UserRouteRoute,
-  } as any)
-const AuthRunsRun_barcodeSamplesheetRouteRoute =
-  AuthRunsRun_barcodeSamplesheetRouteRouteImport.update({
+
+const UserOauthProviderCallbackRoute = UserOauthProviderCallbackImport.update({
+  id: '/oauth/$provider/callback',
+  path: '/oauth/$provider/callback',
+  getParentRoute: () => UserRouteRoute,
+} as any)
+
+const AuthRunsRunbarcodeSamplesheetRouteRoute =
+  AuthRunsRunbarcodeSamplesheetRouteImport.update({
     id: '/samplesheet',
     path: '/samplesheet',
-    getParentRoute: () => AuthRunsRun_barcodeRouteRoute,
-  } as any)
-const AuthRunsRun_barcodeIndexqcRouteRoute =
-  AuthRunsRun_barcodeIndexqcRouteRouteImport.update({
-    id: '/indexqc',
-    path: '/indexqc',
-    getParentRoute: () => AuthRunsRun_barcodeRouteRoute,
-  } as any)
-const AuthRunsRun_barcodeSamplesheetIndexRoute =
-  AuthRunsRun_barcodeSamplesheetIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => AuthRunsRun_barcodeSamplesheetRouteRoute,
-  } as any)
-const AuthRunsRun_barcodeIndexqcIndexRoute =
-  AuthRunsRun_barcodeIndexqcIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => AuthRunsRun_barcodeIndexqcRouteRoute,
+    getParentRoute: () => AuthRunsRunbarcodeRouteRoute,
   } as any)
 
-export interface FileRoutesByFullPath {
-  '/': typeof AuthIndexRoute
-  '/admin': typeof AuthAdminRouteRouteWithChildren
-  '/jobs': typeof AuthJobsRouteRouteWithChildren
-  '/profile': typeof AuthProfileRouteRouteWithChildren
-  '/projects': typeof AuthProjectsRouteRouteWithChildren
-  '/runs': typeof AuthRunsRouteRouteWithChildren
-  '/reset-password': typeof UserResetPasswordRoute
-  '/verify-email': typeof UserVerifyEmailRoute
-  '/admin/jobs': typeof AuthAdminJobsRouteRouteWithChildren
-  '/admin/project-settings': typeof AuthAdminProjectSettingsRouteRouteWithChildren
-  '/admin/run-settings': typeof AuthAdminRunSettingsRouteRouteWithChildren
-  '/admin/vendors': typeof AuthAdminVendorsRouteRouteWithChildren
-  '/jobs/$job_id': typeof AuthJobsJob_idRouteRouteWithChildren
-  '/projects/$project_id': typeof AuthProjectsProject_idRouteRouteWithChildren
-  '/runs/$run_barcode': typeof AuthRunsRun_barcodeRouteRouteWithChildren
-  '/admin/': typeof AuthAdminIndexRoute
-  '/jobs/': typeof AuthJobsIndexRoute
-  '/profile/': typeof AuthProfileIndexRoute
-  '/projects/': typeof AuthProjectsIndexRoute
-  '/runs/': typeof AuthRunsIndexRoute
-  '/access-denied/': typeof UserAccessDeniedIndexRoute
-  '/forgot-password/': typeof UserForgotPasswordIndexRoute
-  '/login/': typeof UserLoginIndexRoute
-  '/register/': typeof UserRegisterIndexRoute
-  '/runs/$run_barcode/indexqc': typeof AuthRunsRun_barcodeIndexqcRouteRouteWithChildren
-  '/runs/$run_barcode/samplesheet': typeof AuthRunsRun_barcodeSamplesheetRouteRouteWithChildren
-  '/oauth/$provider/callback': typeof UserOauthProviderCallbackRoute
-  '/admin/jobs/': typeof AuthAdminJobsIndexRoute
-  '/admin/project-settings/': typeof AuthAdminProjectSettingsIndexRoute
-  '/admin/run-settings/': typeof AuthAdminRunSettingsIndexRoute
-  '/admin/vendors/': typeof AuthAdminVendorsIndexRoute
-  '/jobs/$job_id/': typeof AuthJobsJob_idIndexRoute
-  '/projects/$project_id/': typeof AuthProjectsProject_idIndexRoute
-  '/runs/$run_barcode/': typeof AuthRunsRun_barcodeIndexRoute
-  '/runs/$run_barcode/indexqc/': typeof AuthRunsRun_barcodeIndexqcIndexRoute
-  '/runs/$run_barcode/samplesheet/': typeof AuthRunsRun_barcodeSamplesheetIndexRoute
-}
-export interface FileRoutesByTo {
-  '/': typeof AuthIndexRoute
-  '/reset-password': typeof UserResetPasswordRoute
-  '/verify-email': typeof UserVerifyEmailRoute
-  '/admin': typeof AuthAdminIndexRoute
-  '/jobs': typeof AuthJobsIndexRoute
-  '/profile': typeof AuthProfileIndexRoute
-  '/projects': typeof AuthProjectsIndexRoute
-  '/runs': typeof AuthRunsIndexRoute
-  '/access-denied': typeof UserAccessDeniedIndexRoute
-  '/forgot-password': typeof UserForgotPasswordIndexRoute
-  '/login': typeof UserLoginIndexRoute
-  '/register': typeof UserRegisterIndexRoute
-  '/oauth/$provider/callback': typeof UserOauthProviderCallbackRoute
-  '/admin/jobs': typeof AuthAdminJobsIndexRoute
-  '/admin/project-settings': typeof AuthAdminProjectSettingsIndexRoute
-  '/admin/run-settings': typeof AuthAdminRunSettingsIndexRoute
-  '/admin/vendors': typeof AuthAdminVendorsIndexRoute
-  '/jobs/$job_id': typeof AuthJobsJob_idIndexRoute
-  '/projects/$project_id': typeof AuthProjectsProject_idIndexRoute
-  '/runs/$run_barcode': typeof AuthRunsRun_barcodeIndexRoute
-  '/runs/$run_barcode/indexqc': typeof AuthRunsRun_barcodeIndexqcIndexRoute
-  '/runs/$run_barcode/samplesheet': typeof AuthRunsRun_barcodeSamplesheetIndexRoute
-}
-export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/_user': typeof UserRouteRouteWithChildren
-  '/_auth': typeof AuthRouteWithChildren
-  '/_auth/admin': typeof AuthAdminRouteRouteWithChildren
-  '/_auth/jobs': typeof AuthJobsRouteRouteWithChildren
-  '/_auth/profile': typeof AuthProfileRouteRouteWithChildren
-  '/_auth/projects': typeof AuthProjectsRouteRouteWithChildren
-  '/_auth/runs': typeof AuthRunsRouteRouteWithChildren
-  '/_user/reset-password': typeof UserResetPasswordRoute
-  '/_user/verify-email': typeof UserVerifyEmailRoute
-  '/_auth/': typeof AuthIndexRoute
-  '/_auth/admin/jobs': typeof AuthAdminJobsRouteRouteWithChildren
-  '/_auth/admin/project-settings': typeof AuthAdminProjectSettingsRouteRouteWithChildren
-  '/_auth/admin/run-settings': typeof AuthAdminRunSettingsRouteRouteWithChildren
-  '/_auth/admin/vendors': typeof AuthAdminVendorsRouteRouteWithChildren
-  '/_auth/jobs/$job_id': typeof AuthJobsJob_idRouteRouteWithChildren
-  '/_auth/projects/$project_id': typeof AuthProjectsProject_idRouteRouteWithChildren
-  '/_auth/runs/$run_barcode': typeof AuthRunsRun_barcodeRouteRouteWithChildren
-  '/_auth/admin/': typeof AuthAdminIndexRoute
-  '/_auth/jobs/': typeof AuthJobsIndexRoute
-  '/_auth/profile/': typeof AuthProfileIndexRoute
-  '/_auth/projects/': typeof AuthProjectsIndexRoute
-  '/_auth/runs/': typeof AuthRunsIndexRoute
-  '/_user/access-denied/': typeof UserAccessDeniedIndexRoute
-  '/_user/forgot-password/': typeof UserForgotPasswordIndexRoute
-  '/_user/login/': typeof UserLoginIndexRoute
-  '/_user/register/': typeof UserRegisterIndexRoute
-  '/_auth/runs/$run_barcode/indexqc': typeof AuthRunsRun_barcodeIndexqcRouteRouteWithChildren
-  '/_auth/runs/$run_barcode/samplesheet': typeof AuthRunsRun_barcodeSamplesheetRouteRouteWithChildren
-  '/_user/oauth/$provider/callback': typeof UserOauthProviderCallbackRoute
-  '/_auth/admin/jobs/': typeof AuthAdminJobsIndexRoute
-  '/_auth/admin/project-settings/': typeof AuthAdminProjectSettingsIndexRoute
-  '/_auth/admin/run-settings/': typeof AuthAdminRunSettingsIndexRoute
-  '/_auth/admin/vendors/': typeof AuthAdminVendorsIndexRoute
-  '/_auth/jobs/$job_id/': typeof AuthJobsJob_idIndexRoute
-  '/_auth/projects/$project_id/': typeof AuthProjectsProject_idIndexRoute
-  '/_auth/runs/$run_barcode/': typeof AuthRunsRun_barcodeIndexRoute
-  '/_auth/runs/$run_barcode/indexqc/': typeof AuthRunsRun_barcodeIndexqcIndexRoute
-  '/_auth/runs/$run_barcode/samplesheet/': typeof AuthRunsRun_barcodeSamplesheetIndexRoute
-}
-export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths:
-    | '/'
-    | '/admin'
-    | '/jobs'
-    | '/profile'
-    | '/projects'
-    | '/runs'
-    | '/reset-password'
-    | '/verify-email'
-    | '/admin/jobs'
-    | '/admin/project-settings'
-    | '/admin/run-settings'
-    | '/admin/vendors'
-    | '/jobs/$job_id'
-    | '/projects/$project_id'
-    | '/runs/$run_barcode'
-    | '/admin/'
-    | '/jobs/'
-    | '/profile/'
-    | '/projects/'
-    | '/runs/'
-    | '/access-denied/'
-    | '/forgot-password/'
-    | '/login/'
-    | '/register/'
-    | '/runs/$run_barcode/indexqc'
-    | '/runs/$run_barcode/samplesheet'
-    | '/oauth/$provider/callback'
-    | '/admin/jobs/'
-    | '/admin/project-settings/'
-    | '/admin/run-settings/'
-    | '/admin/vendors/'
-    | '/jobs/$job_id/'
-    | '/projects/$project_id/'
-    | '/runs/$run_barcode/'
-    | '/runs/$run_barcode/indexqc/'
-    | '/runs/$run_barcode/samplesheet/'
-  fileRoutesByTo: FileRoutesByTo
-  to:
-    | '/'
-    | '/reset-password'
-    | '/verify-email'
-    | '/admin'
-    | '/jobs'
-    | '/profile'
-    | '/projects'
-    | '/runs'
-    | '/access-denied'
-    | '/forgot-password'
-    | '/login'
-    | '/register'
-    | '/oauth/$provider/callback'
-    | '/admin/jobs'
-    | '/admin/project-settings'
-    | '/admin/run-settings'
-    | '/admin/vendors'
-    | '/jobs/$job_id'
-    | '/projects/$project_id'
-    | '/runs/$run_barcode'
-    | '/runs/$run_barcode/indexqc'
-    | '/runs/$run_barcode/samplesheet'
-  id:
-    | '__root__'
-    | '/_user'
-    | '/_auth'
-    | '/_auth/admin'
-    | '/_auth/jobs'
-    | '/_auth/profile'
-    | '/_auth/projects'
-    | '/_auth/runs'
-    | '/_user/reset-password'
-    | '/_user/verify-email'
-    | '/_auth/'
-    | '/_auth/admin/jobs'
-    | '/_auth/admin/project-settings'
-    | '/_auth/admin/run-settings'
-    | '/_auth/admin/vendors'
-    | '/_auth/jobs/$job_id'
-    | '/_auth/projects/$project_id'
-    | '/_auth/runs/$run_barcode'
-    | '/_auth/admin/'
-    | '/_auth/jobs/'
-    | '/_auth/profile/'
-    | '/_auth/projects/'
-    | '/_auth/runs/'
-    | '/_user/access-denied/'
-    | '/_user/forgot-password/'
-    | '/_user/login/'
-    | '/_user/register/'
-    | '/_auth/runs/$run_barcode/indexqc'
-    | '/_auth/runs/$run_barcode/samplesheet'
-    | '/_user/oauth/$provider/callback'
-    | '/_auth/admin/jobs/'
-    | '/_auth/admin/project-settings/'
-    | '/_auth/admin/run-settings/'
-    | '/_auth/admin/vendors/'
-    | '/_auth/jobs/$job_id/'
-    | '/_auth/projects/$project_id/'
-    | '/_auth/runs/$run_barcode/'
-    | '/_auth/runs/$run_barcode/indexqc/'
-    | '/_auth/runs/$run_barcode/samplesheet/'
-  fileRoutesById: FileRoutesById
-}
-export interface RootRouteChildren {
-  UserRouteRoute: typeof UserRouteRouteWithChildren
-  AuthRoute: typeof AuthRouteWithChildren
-}
+const AuthRunsRunbarcodeIndexqcRouteRoute =
+  AuthRunsRunbarcodeIndexqcRouteImport.update({
+    id: '/indexqc',
+    path: '/indexqc',
+    getParentRoute: () => AuthRunsRunbarcodeRouteRoute,
+  } as any)
+
+const AuthRunsRunbarcodeSamplesheetIndexRoute =
+  AuthRunsRunbarcodeSamplesheetIndexImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthRunsRunbarcodeSamplesheetRouteRoute,
+  } as any)
+
+const AuthRunsRunbarcodeIndexqcIndexRoute =
+  AuthRunsRunbarcodeIndexqcIndexImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthRunsRunbarcodeIndexqcRouteRoute,
+  } as any)
+
+// Populate the FileRoutesByPath interface
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/_auth': {
-      id: '/_auth'
-      path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof AuthRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/_user': {
       id: '/_user'
       path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof UserRouteRouteImport
-      parentRoute: typeof rootRouteImport
+      fullPath: ''
+      preLoaderRoute: typeof UserRouteImport
+      parentRoute: typeof rootRoute
     }
-    '/_auth/': {
-      id: '/_auth/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof AuthIndexRouteImport
-      parentRoute: typeof AuthRoute
-    }
-    '/_user/verify-email': {
-      id: '/_user/verify-email'
-      path: '/verify-email'
-      fullPath: '/verify-email'
-      preLoaderRoute: typeof UserVerifyEmailRouteImport
-      parentRoute: typeof UserRouteRoute
-    }
-    '/_user/reset-password': {
-      id: '/_user/reset-password'
-      path: '/reset-password'
-      fullPath: '/reset-password'
-      preLoaderRoute: typeof UserResetPasswordRouteImport
-      parentRoute: typeof UserRouteRoute
-    }
-    '/_auth/runs': {
-      id: '/_auth/runs'
-      path: '/runs'
-      fullPath: '/runs'
-      preLoaderRoute: typeof AuthRunsRouteRouteImport
-      parentRoute: typeof AuthRoute
-    }
-    '/_auth/projects': {
-      id: '/_auth/projects'
-      path: '/projects'
-      fullPath: '/projects'
-      preLoaderRoute: typeof AuthProjectsRouteRouteImport
-      parentRoute: typeof AuthRoute
-    }
-    '/_auth/profile': {
-      id: '/_auth/profile'
-      path: '/profile'
-      fullPath: '/profile'
-      preLoaderRoute: typeof AuthProfileRouteRouteImport
-      parentRoute: typeof AuthRoute
-    }
-    '/_auth/jobs': {
-      id: '/_auth/jobs'
-      path: '/jobs'
-      fullPath: '/jobs'
-      preLoaderRoute: typeof AuthJobsRouteRouteImport
-      parentRoute: typeof AuthRoute
+    '/_auth': {
+      id: '/_auth'
+      path: ''
+      fullPath: ''
+      preLoaderRoute: typeof AuthImport
+      parentRoute: typeof rootRoute
     }
     '/_auth/admin': {
       id: '/_auth/admin'
       path: '/admin'
       fullPath: '/admin'
-      preLoaderRoute: typeof AuthAdminRouteRouteImport
-      parentRoute: typeof AuthRoute
+      preLoaderRoute: typeof AuthAdminRouteImport
+      parentRoute: typeof AuthImport
     }
-    '/_user/register/': {
-      id: '/_user/register/'
-      path: '/register'
-      fullPath: '/register/'
-      preLoaderRoute: typeof UserRegisterIndexRouteImport
-      parentRoute: typeof UserRouteRoute
+    '/_auth/jobs': {
+      id: '/_auth/jobs'
+      path: '/jobs'
+      fullPath: '/jobs'
+      preLoaderRoute: typeof AuthJobsRouteImport
+      parentRoute: typeof AuthImport
     }
-    '/_user/login/': {
-      id: '/_user/login/'
-      path: '/login'
-      fullPath: '/login/'
-      preLoaderRoute: typeof UserLoginIndexRouteImport
-      parentRoute: typeof UserRouteRoute
+    '/_auth/profile': {
+      id: '/_auth/profile'
+      path: '/profile'
+      fullPath: '/profile'
+      preLoaderRoute: typeof AuthProfileRouteImport
+      parentRoute: typeof AuthImport
     }
-    '/_user/forgot-password/': {
-      id: '/_user/forgot-password/'
-      path: '/forgot-password'
-      fullPath: '/forgot-password/'
-      preLoaderRoute: typeof UserForgotPasswordIndexRouteImport
-      parentRoute: typeof UserRouteRoute
+    '/_auth/projects': {
+      id: '/_auth/projects'
+      path: '/projects'
+      fullPath: '/projects'
+      preLoaderRoute: typeof AuthProjectsRouteImport
+      parentRoute: typeof AuthImport
     }
-    '/_user/access-denied/': {
-      id: '/_user/access-denied/'
-      path: '/access-denied'
-      fullPath: '/access-denied/'
-      preLoaderRoute: typeof UserAccessDeniedIndexRouteImport
-      parentRoute: typeof UserRouteRoute
+    '/_auth/runs': {
+      id: '/_auth/runs'
+      path: '/runs'
+      fullPath: '/runs'
+      preLoaderRoute: typeof AuthRunsRouteImport
+      parentRoute: typeof AuthImport
     }
-    '/_auth/runs/': {
-      id: '/_auth/runs/'
+    '/_user/reset-password': {
+      id: '/_user/reset-password'
+      path: '/reset-password'
+      fullPath: '/reset-password'
+      preLoaderRoute: typeof UserResetPasswordImport
+      parentRoute: typeof UserRouteImport
+    }
+    '/_user/verify-email': {
+      id: '/_user/verify-email'
+      path: '/verify-email'
+      fullPath: '/verify-email'
+      preLoaderRoute: typeof UserVerifyEmailImport
+      parentRoute: typeof UserRouteImport
+    }
+    '/_auth/': {
+      id: '/_auth/'
       path: '/'
-      fullPath: '/runs/'
-      preLoaderRoute: typeof AuthRunsIndexRouteImport
-      parentRoute: typeof AuthRunsRouteRoute
-    }
-    '/_auth/projects/': {
-      id: '/_auth/projects/'
-      path: '/'
-      fullPath: '/projects/'
-      preLoaderRoute: typeof AuthProjectsIndexRouteImport
-      parentRoute: typeof AuthProjectsRouteRoute
-    }
-    '/_auth/profile/': {
-      id: '/_auth/profile/'
-      path: '/'
-      fullPath: '/profile/'
-      preLoaderRoute: typeof AuthProfileIndexRouteImport
-      parentRoute: typeof AuthProfileRouteRoute
-    }
-    '/_auth/jobs/': {
-      id: '/_auth/jobs/'
-      path: '/'
-      fullPath: '/jobs/'
-      preLoaderRoute: typeof AuthJobsIndexRouteImport
-      parentRoute: typeof AuthJobsRouteRoute
-    }
-    '/_auth/admin/': {
-      id: '/_auth/admin/'
-      path: '/'
-      fullPath: '/admin/'
-      preLoaderRoute: typeof AuthAdminIndexRouteImport
-      parentRoute: typeof AuthAdminRouteRoute
-    }
-    '/_auth/runs/$run_barcode': {
-      id: '/_auth/runs/$run_barcode'
-      path: '/$run_barcode'
-      fullPath: '/runs/$run_barcode'
-      preLoaderRoute: typeof AuthRunsRun_barcodeRouteRouteImport
-      parentRoute: typeof AuthRunsRouteRoute
-    }
-    '/_auth/projects/$project_id': {
-      id: '/_auth/projects/$project_id'
-      path: '/$project_id'
-      fullPath: '/projects/$project_id'
-      preLoaderRoute: typeof AuthProjectsProject_idRouteRouteImport
-      parentRoute: typeof AuthProjectsRouteRoute
-    }
-    '/_auth/jobs/$job_id': {
-      id: '/_auth/jobs/$job_id'
-      path: '/$job_id'
-      fullPath: '/jobs/$job_id'
-      preLoaderRoute: typeof AuthJobsJob_idRouteRouteImport
-      parentRoute: typeof AuthJobsRouteRoute
-    }
-    '/_auth/admin/vendors': {
-      id: '/_auth/admin/vendors'
-      path: '/vendors'
-      fullPath: '/admin/vendors'
-      preLoaderRoute: typeof AuthAdminVendorsRouteRouteImport
-      parentRoute: typeof AuthAdminRouteRoute
-    }
-    '/_auth/admin/run-settings': {
-      id: '/_auth/admin/run-settings'
-      path: '/run-settings'
-      fullPath: '/admin/run-settings'
-      preLoaderRoute: typeof AuthAdminRunSettingsRouteRouteImport
-      parentRoute: typeof AuthAdminRouteRoute
-    }
-    '/_auth/admin/project-settings': {
-      id: '/_auth/admin/project-settings'
-      path: '/project-settings'
-      fullPath: '/admin/project-settings'
-      preLoaderRoute: typeof AuthAdminProjectSettingsRouteRouteImport
-      parentRoute: typeof AuthAdminRouteRoute
+      fullPath: '/'
+      preLoaderRoute: typeof AuthIndexImport
+      parentRoute: typeof AuthImport
     }
     '/_auth/admin/jobs': {
       id: '/_auth/admin/jobs'
       path: '/jobs'
       fullPath: '/admin/jobs'
-      preLoaderRoute: typeof AuthAdminJobsRouteRouteImport
-      parentRoute: typeof AuthAdminRouteRoute
+      preLoaderRoute: typeof AuthAdminJobsRouteImport
+      parentRoute: typeof AuthAdminRouteImport
     }
-    '/_auth/runs/$run_barcode/': {
-      id: '/_auth/runs/$run_barcode/'
+    '/_auth/admin/project-settings': {
+      id: '/_auth/admin/project-settings'
+      path: '/project-settings'
+      fullPath: '/admin/project-settings'
+      preLoaderRoute: typeof AuthAdminProjectSettingsRouteImport
+      parentRoute: typeof AuthAdminRouteImport
+    }
+    '/_auth/admin/run-settings': {
+      id: '/_auth/admin/run-settings'
+      path: '/run-settings'
+      fullPath: '/admin/run-settings'
+      preLoaderRoute: typeof AuthAdminRunSettingsRouteImport
+      parentRoute: typeof AuthAdminRouteImport
+    }
+    '/_auth/admin/vendors': {
+      id: '/_auth/admin/vendors'
+      path: '/vendors'
+      fullPath: '/admin/vendors'
+      preLoaderRoute: typeof AuthAdminVendorsRouteImport
+      parentRoute: typeof AuthAdminRouteImport
+    }
+    '/_auth/jobs/$job_id': {
+      id: '/_auth/jobs/$job_id'
+      path: '/$job_id'
+      fullPath: '/jobs/$job_id'
+      preLoaderRoute: typeof AuthJobsJobidRouteImport
+      parentRoute: typeof AuthJobsRouteImport
+    }
+    '/_auth/projects/$project_id': {
+      id: '/_auth/projects/$project_id'
+      path: '/$project_id'
+      fullPath: '/projects/$project_id'
+      preLoaderRoute: typeof AuthProjectsProjectidRouteImport
+      parentRoute: typeof AuthProjectsRouteImport
+    }
+    '/_auth/runs/$run_barcode': {
+      id: '/_auth/runs/$run_barcode'
+      path: '/$run_barcode'
+      fullPath: '/runs/$run_barcode'
+      preLoaderRoute: typeof AuthRunsRunbarcodeRouteImport
+      parentRoute: typeof AuthRunsRouteImport
+    }
+    '/_auth/admin/': {
+      id: '/_auth/admin/'
       path: '/'
-      fullPath: '/runs/$run_barcode/'
-      preLoaderRoute: typeof AuthRunsRun_barcodeIndexRouteImport
-      parentRoute: typeof AuthRunsRun_barcodeRouteRoute
+      fullPath: '/admin/'
+      preLoaderRoute: typeof AuthAdminIndexImport
+      parentRoute: typeof AuthAdminRouteImport
     }
-    '/_auth/projects/$project_id/': {
-      id: '/_auth/projects/$project_id/'
+    '/_auth/jobs/': {
+      id: '/_auth/jobs/'
       path: '/'
-      fullPath: '/projects/$project_id/'
-      preLoaderRoute: typeof AuthProjectsProject_idIndexRouteImport
-      parentRoute: typeof AuthProjectsProject_idRouteRoute
+      fullPath: '/jobs/'
+      preLoaderRoute: typeof AuthJobsIndexImport
+      parentRoute: typeof AuthJobsRouteImport
     }
-    '/_auth/jobs/$job_id/': {
-      id: '/_auth/jobs/$job_id/'
+    '/_auth/profile/': {
+      id: '/_auth/profile/'
       path: '/'
-      fullPath: '/jobs/$job_id/'
-      preLoaderRoute: typeof AuthJobsJob_idIndexRouteImport
-      parentRoute: typeof AuthJobsJob_idRouteRoute
+      fullPath: '/profile/'
+      preLoaderRoute: typeof AuthProfileIndexImport
+      parentRoute: typeof AuthProfileRouteImport
     }
-    '/_auth/admin/vendors/': {
-      id: '/_auth/admin/vendors/'
+    '/_auth/projects/': {
+      id: '/_auth/projects/'
       path: '/'
-      fullPath: '/admin/vendors/'
-      preLoaderRoute: typeof AuthAdminVendorsIndexRouteImport
-      parentRoute: typeof AuthAdminVendorsRouteRoute
+      fullPath: '/projects/'
+      preLoaderRoute: typeof AuthProjectsIndexImport
+      parentRoute: typeof AuthProjectsRouteImport
     }
-    '/_auth/admin/run-settings/': {
-      id: '/_auth/admin/run-settings/'
+    '/_auth/runs/': {
+      id: '/_auth/runs/'
       path: '/'
-      fullPath: '/admin/run-settings/'
-      preLoaderRoute: typeof AuthAdminRunSettingsIndexRouteImport
-      parentRoute: typeof AuthAdminRunSettingsRouteRoute
+      fullPath: '/runs/'
+      preLoaderRoute: typeof AuthRunsIndexImport
+      parentRoute: typeof AuthRunsRouteImport
     }
-    '/_auth/admin/project-settings/': {
-      id: '/_auth/admin/project-settings/'
-      path: '/'
-      fullPath: '/admin/project-settings/'
-      preLoaderRoute: typeof AuthAdminProjectSettingsIndexRouteImport
-      parentRoute: typeof AuthAdminProjectSettingsRouteRoute
+    '/_user/access-denied/': {
+      id: '/_user/access-denied/'
+      path: '/access-denied'
+      fullPath: '/access-denied'
+      preLoaderRoute: typeof UserAccessDeniedIndexImport
+      parentRoute: typeof UserRouteImport
     }
-    '/_auth/admin/jobs/': {
-      id: '/_auth/admin/jobs/'
-      path: '/'
-      fullPath: '/admin/jobs/'
-      preLoaderRoute: typeof AuthAdminJobsIndexRouteImport
-      parentRoute: typeof AuthAdminJobsRouteRoute
+    '/_user/forgot-password/': {
+      id: '/_user/forgot-password/'
+      path: '/forgot-password'
+      fullPath: '/forgot-password'
+      preLoaderRoute: typeof UserForgotPasswordIndexImport
+      parentRoute: typeof UserRouteImport
     }
-    '/_user/oauth/$provider/callback': {
-      id: '/_user/oauth/$provider/callback'
-      path: '/oauth/$provider/callback'
-      fullPath: '/oauth/$provider/callback'
-      preLoaderRoute: typeof UserOauthProviderCallbackRouteImport
-      parentRoute: typeof UserRouteRoute
+    '/_user/login/': {
+      id: '/_user/login/'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof UserLoginIndexImport
+      parentRoute: typeof UserRouteImport
     }
-    '/_auth/runs/$run_barcode/samplesheet': {
-      id: '/_auth/runs/$run_barcode/samplesheet'
-      path: '/samplesheet'
-      fullPath: '/runs/$run_barcode/samplesheet'
-      preLoaderRoute: typeof AuthRunsRun_barcodeSamplesheetRouteRouteImport
-      parentRoute: typeof AuthRunsRun_barcodeRouteRoute
+    '/_user/register/': {
+      id: '/_user/register/'
+      path: '/register'
+      fullPath: '/register'
+      preLoaderRoute: typeof UserRegisterIndexImport
+      parentRoute: typeof UserRouteImport
     }
     '/_auth/runs/$run_barcode/indexqc': {
       id: '/_auth/runs/$run_barcode/indexqc'
       path: '/indexqc'
       fullPath: '/runs/$run_barcode/indexqc'
-      preLoaderRoute: typeof AuthRunsRun_barcodeIndexqcRouteRouteImport
-      parentRoute: typeof AuthRunsRun_barcodeRouteRoute
+      preLoaderRoute: typeof AuthRunsRunbarcodeIndexqcRouteImport
+      parentRoute: typeof AuthRunsRunbarcodeRouteImport
     }
-    '/_auth/runs/$run_barcode/samplesheet/': {
-      id: '/_auth/runs/$run_barcode/samplesheet/'
+    '/_auth/runs/$run_barcode/samplesheet': {
+      id: '/_auth/runs/$run_barcode/samplesheet'
+      path: '/samplesheet'
+      fullPath: '/runs/$run_barcode/samplesheet'
+      preLoaderRoute: typeof AuthRunsRunbarcodeSamplesheetRouteImport
+      parentRoute: typeof AuthRunsRunbarcodeRouteImport
+    }
+    '/_user/oauth/$provider/callback': {
+      id: '/_user/oauth/$provider/callback'
+      path: '/oauth/$provider/callback'
+      fullPath: '/oauth/$provider/callback'
+      preLoaderRoute: typeof UserOauthProviderCallbackImport
+      parentRoute: typeof UserRouteImport
+    }
+    '/_auth/admin/jobs/': {
+      id: '/_auth/admin/jobs/'
       path: '/'
-      fullPath: '/runs/$run_barcode/samplesheet/'
-      preLoaderRoute: typeof AuthRunsRun_barcodeSamplesheetIndexRouteImport
-      parentRoute: typeof AuthRunsRun_barcodeSamplesheetRouteRoute
+      fullPath: '/admin/jobs/'
+      preLoaderRoute: typeof AuthAdminJobsIndexImport
+      parentRoute: typeof AuthAdminJobsRouteImport
+    }
+    '/_auth/admin/project-settings/': {
+      id: '/_auth/admin/project-settings/'
+      path: '/'
+      fullPath: '/admin/project-settings/'
+      preLoaderRoute: typeof AuthAdminProjectSettingsIndexImport
+      parentRoute: typeof AuthAdminProjectSettingsRouteImport
+    }
+    '/_auth/admin/run-settings/': {
+      id: '/_auth/admin/run-settings/'
+      path: '/'
+      fullPath: '/admin/run-settings/'
+      preLoaderRoute: typeof AuthAdminRunSettingsIndexImport
+      parentRoute: typeof AuthAdminRunSettingsRouteImport
+    }
+    '/_auth/admin/vendors/': {
+      id: '/_auth/admin/vendors/'
+      path: '/'
+      fullPath: '/admin/vendors/'
+      preLoaderRoute: typeof AuthAdminVendorsIndexImport
+      parentRoute: typeof AuthAdminVendorsRouteImport
+    }
+    '/_auth/jobs/$job_id/': {
+      id: '/_auth/jobs/$job_id/'
+      path: '/'
+      fullPath: '/jobs/$job_id/'
+      preLoaderRoute: typeof AuthJobsJobidIndexImport
+      parentRoute: typeof AuthJobsJobidRouteImport
+    }
+    '/_auth/projects/$project_id/': {
+      id: '/_auth/projects/$project_id/'
+      path: '/'
+      fullPath: '/projects/$project_id/'
+      preLoaderRoute: typeof AuthProjectsProjectidIndexImport
+      parentRoute: typeof AuthProjectsProjectidRouteImport
+    }
+    '/_auth/runs/$run_barcode/': {
+      id: '/_auth/runs/$run_barcode/'
+      path: '/'
+      fullPath: '/runs/$run_barcode/'
+      preLoaderRoute: typeof AuthRunsRunbarcodeIndexImport
+      parentRoute: typeof AuthRunsRunbarcodeRouteImport
     }
     '/_auth/runs/$run_barcode/indexqc/': {
       id: '/_auth/runs/$run_barcode/indexqc/'
       path: '/'
       fullPath: '/runs/$run_barcode/indexqc/'
-      preLoaderRoute: typeof AuthRunsRun_barcodeIndexqcIndexRouteImport
-      parentRoute: typeof AuthRunsRun_barcodeIndexqcRouteRoute
+      preLoaderRoute: typeof AuthRunsRunbarcodeIndexqcIndexImport
+      parentRoute: typeof AuthRunsRunbarcodeIndexqcRouteImport
+    }
+    '/_auth/runs/$run_barcode/samplesheet/': {
+      id: '/_auth/runs/$run_barcode/samplesheet/'
+      path: '/'
+      fullPath: '/runs/$run_barcode/samplesheet/'
+      preLoaderRoute: typeof AuthRunsRunbarcodeSamplesheetIndexImport
+      parentRoute: typeof AuthRunsRunbarcodeSamplesheetRouteImport
     }
   }
 }
+
+// Create and export the route tree
 
 interface UserRouteRouteChildren {
   UserResetPasswordRoute: typeof UserResetPasswordRoute
@@ -831,24 +660,24 @@ const AuthAdminRouteRouteWithChildren = AuthAdminRouteRoute._addFileChildren(
   AuthAdminRouteRouteChildren,
 )
 
-interface AuthJobsJob_idRouteRouteChildren {
-  AuthJobsJob_idIndexRoute: typeof AuthJobsJob_idIndexRoute
+interface AuthJobsJobidRouteRouteChildren {
+  AuthJobsJobidIndexRoute: typeof AuthJobsJobidIndexRoute
 }
 
-const AuthJobsJob_idRouteRouteChildren: AuthJobsJob_idRouteRouteChildren = {
-  AuthJobsJob_idIndexRoute: AuthJobsJob_idIndexRoute,
+const AuthJobsJobidRouteRouteChildren: AuthJobsJobidRouteRouteChildren = {
+  AuthJobsJobidIndexRoute: AuthJobsJobidIndexRoute,
 }
 
-const AuthJobsJob_idRouteRouteWithChildren =
-  AuthJobsJob_idRouteRoute._addFileChildren(AuthJobsJob_idRouteRouteChildren)
+const AuthJobsJobidRouteRouteWithChildren =
+  AuthJobsJobidRouteRoute._addFileChildren(AuthJobsJobidRouteRouteChildren)
 
 interface AuthJobsRouteRouteChildren {
-  AuthJobsJob_idRouteRoute: typeof AuthJobsJob_idRouteRouteWithChildren
+  AuthJobsJobidRouteRoute: typeof AuthJobsJobidRouteRouteWithChildren
   AuthJobsIndexRoute: typeof AuthJobsIndexRoute
 }
 
 const AuthJobsRouteRouteChildren: AuthJobsRouteRouteChildren = {
-  AuthJobsJob_idRouteRoute: AuthJobsJob_idRouteRouteWithChildren,
+  AuthJobsJobidRouteRoute: AuthJobsJobidRouteRouteWithChildren,
   AuthJobsIndexRoute: AuthJobsIndexRoute,
 }
 
@@ -867,90 +696,89 @@ const AuthProfileRouteRouteChildren: AuthProfileRouteRouteChildren = {
 const AuthProfileRouteRouteWithChildren =
   AuthProfileRouteRoute._addFileChildren(AuthProfileRouteRouteChildren)
 
-interface AuthProjectsProject_idRouteRouteChildren {
-  AuthProjectsProject_idIndexRoute: typeof AuthProjectsProject_idIndexRoute
+interface AuthProjectsProjectidRouteRouteChildren {
+  AuthProjectsProjectidIndexRoute: typeof AuthProjectsProjectidIndexRoute
 }
 
-const AuthProjectsProject_idRouteRouteChildren: AuthProjectsProject_idRouteRouteChildren =
+const AuthProjectsProjectidRouteRouteChildren: AuthProjectsProjectidRouteRouteChildren =
   {
-    AuthProjectsProject_idIndexRoute: AuthProjectsProject_idIndexRoute,
+    AuthProjectsProjectidIndexRoute: AuthProjectsProjectidIndexRoute,
   }
 
-const AuthProjectsProject_idRouteRouteWithChildren =
-  AuthProjectsProject_idRouteRoute._addFileChildren(
-    AuthProjectsProject_idRouteRouteChildren,
+const AuthProjectsProjectidRouteRouteWithChildren =
+  AuthProjectsProjectidRouteRoute._addFileChildren(
+    AuthProjectsProjectidRouteRouteChildren,
   )
 
 interface AuthProjectsRouteRouteChildren {
-  AuthProjectsProject_idRouteRoute: typeof AuthProjectsProject_idRouteRouteWithChildren
+  AuthProjectsProjectidRouteRoute: typeof AuthProjectsProjectidRouteRouteWithChildren
   AuthProjectsIndexRoute: typeof AuthProjectsIndexRoute
 }
 
 const AuthProjectsRouteRouteChildren: AuthProjectsRouteRouteChildren = {
-  AuthProjectsProject_idRouteRoute:
-    AuthProjectsProject_idRouteRouteWithChildren,
+  AuthProjectsProjectidRouteRoute: AuthProjectsProjectidRouteRouteWithChildren,
   AuthProjectsIndexRoute: AuthProjectsIndexRoute,
 }
 
 const AuthProjectsRouteRouteWithChildren =
   AuthProjectsRouteRoute._addFileChildren(AuthProjectsRouteRouteChildren)
 
-interface AuthRunsRun_barcodeIndexqcRouteRouteChildren {
-  AuthRunsRun_barcodeIndexqcIndexRoute: typeof AuthRunsRun_barcodeIndexqcIndexRoute
+interface AuthRunsRunbarcodeIndexqcRouteRouteChildren {
+  AuthRunsRunbarcodeIndexqcIndexRoute: typeof AuthRunsRunbarcodeIndexqcIndexRoute
 }
 
-const AuthRunsRun_barcodeIndexqcRouteRouteChildren: AuthRunsRun_barcodeIndexqcRouteRouteChildren =
+const AuthRunsRunbarcodeIndexqcRouteRouteChildren: AuthRunsRunbarcodeIndexqcRouteRouteChildren =
   {
-    AuthRunsRun_barcodeIndexqcIndexRoute: AuthRunsRun_barcodeIndexqcIndexRoute,
+    AuthRunsRunbarcodeIndexqcIndexRoute: AuthRunsRunbarcodeIndexqcIndexRoute,
   }
 
-const AuthRunsRun_barcodeIndexqcRouteRouteWithChildren =
-  AuthRunsRun_barcodeIndexqcRouteRoute._addFileChildren(
-    AuthRunsRun_barcodeIndexqcRouteRouteChildren,
+const AuthRunsRunbarcodeIndexqcRouteRouteWithChildren =
+  AuthRunsRunbarcodeIndexqcRouteRoute._addFileChildren(
+    AuthRunsRunbarcodeIndexqcRouteRouteChildren,
   )
 
-interface AuthRunsRun_barcodeSamplesheetRouteRouteChildren {
-  AuthRunsRun_barcodeSamplesheetIndexRoute: typeof AuthRunsRun_barcodeSamplesheetIndexRoute
+interface AuthRunsRunbarcodeSamplesheetRouteRouteChildren {
+  AuthRunsRunbarcodeSamplesheetIndexRoute: typeof AuthRunsRunbarcodeSamplesheetIndexRoute
 }
 
-const AuthRunsRun_barcodeSamplesheetRouteRouteChildren: AuthRunsRun_barcodeSamplesheetRouteRouteChildren =
+const AuthRunsRunbarcodeSamplesheetRouteRouteChildren: AuthRunsRunbarcodeSamplesheetRouteRouteChildren =
   {
-    AuthRunsRun_barcodeSamplesheetIndexRoute:
-      AuthRunsRun_barcodeSamplesheetIndexRoute,
+    AuthRunsRunbarcodeSamplesheetIndexRoute:
+      AuthRunsRunbarcodeSamplesheetIndexRoute,
   }
 
-const AuthRunsRun_barcodeSamplesheetRouteRouteWithChildren =
-  AuthRunsRun_barcodeSamplesheetRouteRoute._addFileChildren(
-    AuthRunsRun_barcodeSamplesheetRouteRouteChildren,
+const AuthRunsRunbarcodeSamplesheetRouteRouteWithChildren =
+  AuthRunsRunbarcodeSamplesheetRouteRoute._addFileChildren(
+    AuthRunsRunbarcodeSamplesheetRouteRouteChildren,
   )
 
-interface AuthRunsRun_barcodeRouteRouteChildren {
-  AuthRunsRun_barcodeIndexqcRouteRoute: typeof AuthRunsRun_barcodeIndexqcRouteRouteWithChildren
-  AuthRunsRun_barcodeSamplesheetRouteRoute: typeof AuthRunsRun_barcodeSamplesheetRouteRouteWithChildren
-  AuthRunsRun_barcodeIndexRoute: typeof AuthRunsRun_barcodeIndexRoute
+interface AuthRunsRunbarcodeRouteRouteChildren {
+  AuthRunsRunbarcodeIndexqcRouteRoute: typeof AuthRunsRunbarcodeIndexqcRouteRouteWithChildren
+  AuthRunsRunbarcodeSamplesheetRouteRoute: typeof AuthRunsRunbarcodeSamplesheetRouteRouteWithChildren
+  AuthRunsRunbarcodeIndexRoute: typeof AuthRunsRunbarcodeIndexRoute
 }
 
-const AuthRunsRun_barcodeRouteRouteChildren: AuthRunsRun_barcodeRouteRouteChildren =
+const AuthRunsRunbarcodeRouteRouteChildren: AuthRunsRunbarcodeRouteRouteChildren =
   {
-    AuthRunsRun_barcodeIndexqcRouteRoute:
-      AuthRunsRun_barcodeIndexqcRouteRouteWithChildren,
-    AuthRunsRun_barcodeSamplesheetRouteRoute:
-      AuthRunsRun_barcodeSamplesheetRouteRouteWithChildren,
-    AuthRunsRun_barcodeIndexRoute: AuthRunsRun_barcodeIndexRoute,
+    AuthRunsRunbarcodeIndexqcRouteRoute:
+      AuthRunsRunbarcodeIndexqcRouteRouteWithChildren,
+    AuthRunsRunbarcodeSamplesheetRouteRoute:
+      AuthRunsRunbarcodeSamplesheetRouteRouteWithChildren,
+    AuthRunsRunbarcodeIndexRoute: AuthRunsRunbarcodeIndexRoute,
   }
 
-const AuthRunsRun_barcodeRouteRouteWithChildren =
-  AuthRunsRun_barcodeRouteRoute._addFileChildren(
-    AuthRunsRun_barcodeRouteRouteChildren,
+const AuthRunsRunbarcodeRouteRouteWithChildren =
+  AuthRunsRunbarcodeRouteRoute._addFileChildren(
+    AuthRunsRunbarcodeRouteRouteChildren,
   )
 
 interface AuthRunsRouteRouteChildren {
-  AuthRunsRun_barcodeRouteRoute: typeof AuthRunsRun_barcodeRouteRouteWithChildren
+  AuthRunsRunbarcodeRouteRoute: typeof AuthRunsRunbarcodeRouteRouteWithChildren
   AuthRunsIndexRoute: typeof AuthRunsIndexRoute
 }
 
 const AuthRunsRouteRouteChildren: AuthRunsRouteRouteChildren = {
-  AuthRunsRun_barcodeRouteRoute: AuthRunsRun_barcodeRouteRouteWithChildren,
+  AuthRunsRunbarcodeRouteRoute: AuthRunsRunbarcodeRouteRouteWithChildren,
   AuthRunsIndexRoute: AuthRunsIndexRoute,
 }
 
@@ -978,10 +806,464 @@ const AuthRouteChildren: AuthRouteChildren = {
 
 const AuthRouteWithChildren = AuthRoute._addFileChildren(AuthRouteChildren)
 
+export interface FileRoutesByFullPath {
+  '': typeof AuthRouteWithChildren
+  '/admin': typeof AuthAdminRouteRouteWithChildren
+  '/jobs': typeof AuthJobsRouteRouteWithChildren
+  '/profile': typeof AuthProfileRouteRouteWithChildren
+  '/projects': typeof AuthProjectsRouteRouteWithChildren
+  '/runs': typeof AuthRunsRouteRouteWithChildren
+  '/reset-password': typeof UserResetPasswordRoute
+  '/verify-email': typeof UserVerifyEmailRoute
+  '/': typeof AuthIndexRoute
+  '/admin/jobs': typeof AuthAdminJobsRouteRouteWithChildren
+  '/admin/project-settings': typeof AuthAdminProjectSettingsRouteRouteWithChildren
+  '/admin/run-settings': typeof AuthAdminRunSettingsRouteRouteWithChildren
+  '/admin/vendors': typeof AuthAdminVendorsRouteRouteWithChildren
+  '/jobs/$job_id': typeof AuthJobsJobidRouteRouteWithChildren
+  '/projects/$project_id': typeof AuthProjectsProjectidRouteRouteWithChildren
+  '/runs/$run_barcode': typeof AuthRunsRunbarcodeRouteRouteWithChildren
+  '/admin/': typeof AuthAdminIndexRoute
+  '/jobs/': typeof AuthJobsIndexRoute
+  '/profile/': typeof AuthProfileIndexRoute
+  '/projects/': typeof AuthProjectsIndexRoute
+  '/runs/': typeof AuthRunsIndexRoute
+  '/access-denied': typeof UserAccessDeniedIndexRoute
+  '/forgot-password': typeof UserForgotPasswordIndexRoute
+  '/login': typeof UserLoginIndexRoute
+  '/register': typeof UserRegisterIndexRoute
+  '/runs/$run_barcode/indexqc': typeof AuthRunsRunbarcodeIndexqcRouteRouteWithChildren
+  '/runs/$run_barcode/samplesheet': typeof AuthRunsRunbarcodeSamplesheetRouteRouteWithChildren
+  '/oauth/$provider/callback': typeof UserOauthProviderCallbackRoute
+  '/admin/jobs/': typeof AuthAdminJobsIndexRoute
+  '/admin/project-settings/': typeof AuthAdminProjectSettingsIndexRoute
+  '/admin/run-settings/': typeof AuthAdminRunSettingsIndexRoute
+  '/admin/vendors/': typeof AuthAdminVendorsIndexRoute
+  '/jobs/$job_id/': typeof AuthJobsJobidIndexRoute
+  '/projects/$project_id/': typeof AuthProjectsProjectidIndexRoute
+  '/runs/$run_barcode/': typeof AuthRunsRunbarcodeIndexRoute
+  '/runs/$run_barcode/indexqc/': typeof AuthRunsRunbarcodeIndexqcIndexRoute
+  '/runs/$run_barcode/samplesheet/': typeof AuthRunsRunbarcodeSamplesheetIndexRoute
+}
+
+export interface FileRoutesByTo {
+  '': typeof UserRouteRouteWithChildren
+  '/reset-password': typeof UserResetPasswordRoute
+  '/verify-email': typeof UserVerifyEmailRoute
+  '/': typeof AuthIndexRoute
+  '/admin': typeof AuthAdminIndexRoute
+  '/jobs': typeof AuthJobsIndexRoute
+  '/profile': typeof AuthProfileIndexRoute
+  '/projects': typeof AuthProjectsIndexRoute
+  '/runs': typeof AuthRunsIndexRoute
+  '/access-denied': typeof UserAccessDeniedIndexRoute
+  '/forgot-password': typeof UserForgotPasswordIndexRoute
+  '/login': typeof UserLoginIndexRoute
+  '/register': typeof UserRegisterIndexRoute
+  '/oauth/$provider/callback': typeof UserOauthProviderCallbackRoute
+  '/admin/jobs': typeof AuthAdminJobsIndexRoute
+  '/admin/project-settings': typeof AuthAdminProjectSettingsIndexRoute
+  '/admin/run-settings': typeof AuthAdminRunSettingsIndexRoute
+  '/admin/vendors': typeof AuthAdminVendorsIndexRoute
+  '/jobs/$job_id': typeof AuthJobsJobidIndexRoute
+  '/projects/$project_id': typeof AuthProjectsProjectidIndexRoute
+  '/runs/$run_barcode': typeof AuthRunsRunbarcodeIndexRoute
+  '/runs/$run_barcode/indexqc': typeof AuthRunsRunbarcodeIndexqcIndexRoute
+  '/runs/$run_barcode/samplesheet': typeof AuthRunsRunbarcodeSamplesheetIndexRoute
+}
+
+export interface FileRoutesById {
+  __root__: typeof rootRoute
+  '/_user': typeof UserRouteRouteWithChildren
+  '/_auth': typeof AuthRouteWithChildren
+  '/_auth/admin': typeof AuthAdminRouteRouteWithChildren
+  '/_auth/jobs': typeof AuthJobsRouteRouteWithChildren
+  '/_auth/profile': typeof AuthProfileRouteRouteWithChildren
+  '/_auth/projects': typeof AuthProjectsRouteRouteWithChildren
+  '/_auth/runs': typeof AuthRunsRouteRouteWithChildren
+  '/_user/reset-password': typeof UserResetPasswordRoute
+  '/_user/verify-email': typeof UserVerifyEmailRoute
+  '/_auth/': typeof AuthIndexRoute
+  '/_auth/admin/jobs': typeof AuthAdminJobsRouteRouteWithChildren
+  '/_auth/admin/project-settings': typeof AuthAdminProjectSettingsRouteRouteWithChildren
+  '/_auth/admin/run-settings': typeof AuthAdminRunSettingsRouteRouteWithChildren
+  '/_auth/admin/vendors': typeof AuthAdminVendorsRouteRouteWithChildren
+  '/_auth/jobs/$job_id': typeof AuthJobsJobidRouteRouteWithChildren
+  '/_auth/projects/$project_id': typeof AuthProjectsProjectidRouteRouteWithChildren
+  '/_auth/runs/$run_barcode': typeof AuthRunsRunbarcodeRouteRouteWithChildren
+  '/_auth/admin/': typeof AuthAdminIndexRoute
+  '/_auth/jobs/': typeof AuthJobsIndexRoute
+  '/_auth/profile/': typeof AuthProfileIndexRoute
+  '/_auth/projects/': typeof AuthProjectsIndexRoute
+  '/_auth/runs/': typeof AuthRunsIndexRoute
+  '/_user/access-denied/': typeof UserAccessDeniedIndexRoute
+  '/_user/forgot-password/': typeof UserForgotPasswordIndexRoute
+  '/_user/login/': typeof UserLoginIndexRoute
+  '/_user/register/': typeof UserRegisterIndexRoute
+  '/_auth/runs/$run_barcode/indexqc': typeof AuthRunsRunbarcodeIndexqcRouteRouteWithChildren
+  '/_auth/runs/$run_barcode/samplesheet': typeof AuthRunsRunbarcodeSamplesheetRouteRouteWithChildren
+  '/_user/oauth/$provider/callback': typeof UserOauthProviderCallbackRoute
+  '/_auth/admin/jobs/': typeof AuthAdminJobsIndexRoute
+  '/_auth/admin/project-settings/': typeof AuthAdminProjectSettingsIndexRoute
+  '/_auth/admin/run-settings/': typeof AuthAdminRunSettingsIndexRoute
+  '/_auth/admin/vendors/': typeof AuthAdminVendorsIndexRoute
+  '/_auth/jobs/$job_id/': typeof AuthJobsJobidIndexRoute
+  '/_auth/projects/$project_id/': typeof AuthProjectsProjectidIndexRoute
+  '/_auth/runs/$run_barcode/': typeof AuthRunsRunbarcodeIndexRoute
+  '/_auth/runs/$run_barcode/indexqc/': typeof AuthRunsRunbarcodeIndexqcIndexRoute
+  '/_auth/runs/$run_barcode/samplesheet/': typeof AuthRunsRunbarcodeSamplesheetIndexRoute
+}
+
+export interface FileRouteTypes {
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | ''
+    | '/admin'
+    | '/jobs'
+    | '/profile'
+    | '/projects'
+    | '/runs'
+    | '/reset-password'
+    | '/verify-email'
+    | '/'
+    | '/admin/jobs'
+    | '/admin/project-settings'
+    | '/admin/run-settings'
+    | '/admin/vendors'
+    | '/jobs/$job_id'
+    | '/projects/$project_id'
+    | '/runs/$run_barcode'
+    | '/admin/'
+    | '/jobs/'
+    | '/profile/'
+    | '/projects/'
+    | '/runs/'
+    | '/access-denied'
+    | '/forgot-password'
+    | '/login'
+    | '/register'
+    | '/runs/$run_barcode/indexqc'
+    | '/runs/$run_barcode/samplesheet'
+    | '/oauth/$provider/callback'
+    | '/admin/jobs/'
+    | '/admin/project-settings/'
+    | '/admin/run-settings/'
+    | '/admin/vendors/'
+    | '/jobs/$job_id/'
+    | '/projects/$project_id/'
+    | '/runs/$run_barcode/'
+    | '/runs/$run_barcode/indexqc/'
+    | '/runs/$run_barcode/samplesheet/'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | ''
+    | '/reset-password'
+    | '/verify-email'
+    | '/'
+    | '/admin'
+    | '/jobs'
+    | '/profile'
+    | '/projects'
+    | '/runs'
+    | '/access-denied'
+    | '/forgot-password'
+    | '/login'
+    | '/register'
+    | '/oauth/$provider/callback'
+    | '/admin/jobs'
+    | '/admin/project-settings'
+    | '/admin/run-settings'
+    | '/admin/vendors'
+    | '/jobs/$job_id'
+    | '/projects/$project_id'
+    | '/runs/$run_barcode'
+    | '/runs/$run_barcode/indexqc'
+    | '/runs/$run_barcode/samplesheet'
+  id:
+    | '__root__'
+    | '/_user'
+    | '/_auth'
+    | '/_auth/admin'
+    | '/_auth/jobs'
+    | '/_auth/profile'
+    | '/_auth/projects'
+    | '/_auth/runs'
+    | '/_user/reset-password'
+    | '/_user/verify-email'
+    | '/_auth/'
+    | '/_auth/admin/jobs'
+    | '/_auth/admin/project-settings'
+    | '/_auth/admin/run-settings'
+    | '/_auth/admin/vendors'
+    | '/_auth/jobs/$job_id'
+    | '/_auth/projects/$project_id'
+    | '/_auth/runs/$run_barcode'
+    | '/_auth/admin/'
+    | '/_auth/jobs/'
+    | '/_auth/profile/'
+    | '/_auth/projects/'
+    | '/_auth/runs/'
+    | '/_user/access-denied/'
+    | '/_user/forgot-password/'
+    | '/_user/login/'
+    | '/_user/register/'
+    | '/_auth/runs/$run_barcode/indexqc'
+    | '/_auth/runs/$run_barcode/samplesheet'
+    | '/_user/oauth/$provider/callback'
+    | '/_auth/admin/jobs/'
+    | '/_auth/admin/project-settings/'
+    | '/_auth/admin/run-settings/'
+    | '/_auth/admin/vendors/'
+    | '/_auth/jobs/$job_id/'
+    | '/_auth/projects/$project_id/'
+    | '/_auth/runs/$run_barcode/'
+    | '/_auth/runs/$run_barcode/indexqc/'
+    | '/_auth/runs/$run_barcode/samplesheet/'
+  fileRoutesById: FileRoutesById
+}
+
+export interface RootRouteChildren {
+  UserRouteRoute: typeof UserRouteRouteWithChildren
+  AuthRoute: typeof AuthRouteWithChildren
+}
+
 const rootRouteChildren: RootRouteChildren = {
   UserRouteRoute: UserRouteRouteWithChildren,
   AuthRoute: AuthRouteWithChildren,
 }
-export const routeTree = rootRouteImport
+
+export const routeTree = rootRoute
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+/* ROUTE_MANIFEST_START
+{
+  "routes": {
+    "__root__": {
+      "filePath": "__root.tsx",
+      "children": [
+        "/_user",
+        "/_auth"
+      ]
+    },
+    "/_user": {
+      "filePath": "_user.route.tsx",
+      "children": [
+        "/_user/reset-password",
+        "/_user/verify-email",
+        "/_user/access-denied/",
+        "/_user/forgot-password/",
+        "/_user/login/",
+        "/_user/register/",
+        "/_user/oauth/$provider/callback"
+      ]
+    },
+    "/_auth": {
+      "filePath": "_auth.tsx",
+      "children": [
+        "/_auth/admin",
+        "/_auth/jobs",
+        "/_auth/profile",
+        "/_auth/projects",
+        "/_auth/runs",
+        "/_auth/"
+      ]
+    },
+    "/_auth/admin": {
+      "filePath": "_auth.admin.route.tsx",
+      "parent": "/_auth",
+      "children": [
+        "/_auth/admin/jobs",
+        "/_auth/admin/project-settings",
+        "/_auth/admin/run-settings",
+        "/_auth/admin/vendors",
+        "/_auth/admin/"
+      ]
+    },
+    "/_auth/jobs": {
+      "filePath": "_auth.jobs.route.tsx",
+      "parent": "/_auth",
+      "children": [
+        "/_auth/jobs/$job_id",
+        "/_auth/jobs/"
+      ]
+    },
+    "/_auth/profile": {
+      "filePath": "_auth.profile.route.tsx",
+      "parent": "/_auth",
+      "children": [
+        "/_auth/profile/"
+      ]
+    },
+    "/_auth/projects": {
+      "filePath": "_auth.projects.route.tsx",
+      "parent": "/_auth",
+      "children": [
+        "/_auth/projects/$project_id",
+        "/_auth/projects/"
+      ]
+    },
+    "/_auth/runs": {
+      "filePath": "_auth.runs.route.tsx",
+      "parent": "/_auth",
+      "children": [
+        "/_auth/runs/$run_barcode",
+        "/_auth/runs/"
+      ]
+    },
+    "/_user/reset-password": {
+      "filePath": "_user.reset-password.tsx",
+      "parent": "/_user"
+    },
+    "/_user/verify-email": {
+      "filePath": "_user.verify-email.tsx",
+      "parent": "/_user"
+    },
+    "/_auth/": {
+      "filePath": "_auth.index.tsx",
+      "parent": "/_auth"
+    },
+    "/_auth/admin/jobs": {
+      "filePath": "_auth.admin.jobs.route.tsx",
+      "parent": "/_auth/admin",
+      "children": [
+        "/_auth/admin/jobs/"
+      ]
+    },
+    "/_auth/admin/project-settings": {
+      "filePath": "_auth.admin.project-settings.route.tsx",
+      "parent": "/_auth/admin",
+      "children": [
+        "/_auth/admin/project-settings/"
+      ]
+    },
+    "/_auth/admin/run-settings": {
+      "filePath": "_auth.admin.run-settings.route.tsx",
+      "parent": "/_auth/admin",
+      "children": [
+        "/_auth/admin/run-settings/"
+      ]
+    },
+    "/_auth/admin/vendors": {
+      "filePath": "_auth.admin.vendors.route.tsx",
+      "parent": "/_auth/admin",
+      "children": [
+        "/_auth/admin/vendors/"
+      ]
+    },
+    "/_auth/jobs/$job_id": {
+      "filePath": "_auth.jobs.$job_id.route.tsx",
+      "parent": "/_auth/jobs",
+      "children": [
+        "/_auth/jobs/$job_id/"
+      ]
+    },
+    "/_auth/projects/$project_id": {
+      "filePath": "_auth.projects.$project_id.route.tsx",
+      "parent": "/_auth/projects",
+      "children": [
+        "/_auth/projects/$project_id/"
+      ]
+    },
+    "/_auth/runs/$run_barcode": {
+      "filePath": "_auth.runs.$run_barcode.route.tsx",
+      "parent": "/_auth/runs",
+      "children": [
+        "/_auth/runs/$run_barcode/indexqc",
+        "/_auth/runs/$run_barcode/samplesheet",
+        "/_auth/runs/$run_barcode/"
+      ]
+    },
+    "/_auth/admin/": {
+      "filePath": "_auth.admin.index.tsx",
+      "parent": "/_auth/admin"
+    },
+    "/_auth/jobs/": {
+      "filePath": "_auth.jobs.index.tsx",
+      "parent": "/_auth/jobs"
+    },
+    "/_auth/profile/": {
+      "filePath": "_auth.profile.index.tsx",
+      "parent": "/_auth/profile"
+    },
+    "/_auth/projects/": {
+      "filePath": "_auth.projects.index.tsx",
+      "parent": "/_auth/projects"
+    },
+    "/_auth/runs/": {
+      "filePath": "_auth.runs.index.tsx",
+      "parent": "/_auth/runs"
+    },
+    "/_user/access-denied/": {
+      "filePath": "_user.access-denied.index.tsx",
+      "parent": "/_user"
+    },
+    "/_user/forgot-password/": {
+      "filePath": "_user.forgot-password.index.tsx",
+      "parent": "/_user"
+    },
+    "/_user/login/": {
+      "filePath": "_user.login.index.tsx",
+      "parent": "/_user"
+    },
+    "/_user/register/": {
+      "filePath": "_user.register.index.tsx",
+      "parent": "/_user"
+    },
+    "/_auth/runs/$run_barcode/indexqc": {
+      "filePath": "_auth.runs.$run_barcode.indexqc.route.tsx",
+      "parent": "/_auth/runs/$run_barcode",
+      "children": [
+        "/_auth/runs/$run_barcode/indexqc/"
+      ]
+    },
+    "/_auth/runs/$run_barcode/samplesheet": {
+      "filePath": "_auth.runs.$run_barcode.samplesheet.route.tsx",
+      "parent": "/_auth/runs/$run_barcode",
+      "children": [
+        "/_auth/runs/$run_barcode/samplesheet/"
+      ]
+    },
+    "/_user/oauth/$provider/callback": {
+      "filePath": "_user.oauth.$provider.callback.tsx",
+      "parent": "/_user"
+    },
+    "/_auth/admin/jobs/": {
+      "filePath": "_auth.admin.jobs.index.tsx",
+      "parent": "/_auth/admin/jobs"
+    },
+    "/_auth/admin/project-settings/": {
+      "filePath": "_auth.admin.project-settings.index.tsx",
+      "parent": "/_auth/admin/project-settings"
+    },
+    "/_auth/admin/run-settings/": {
+      "filePath": "_auth.admin.run-settings.index.tsx",
+      "parent": "/_auth/admin/run-settings"
+    },
+    "/_auth/admin/vendors/": {
+      "filePath": "_auth.admin.vendors.index.tsx",
+      "parent": "/_auth/admin/vendors"
+    },
+    "/_auth/jobs/$job_id/": {
+      "filePath": "_auth.jobs.$job_id.index.tsx",
+      "parent": "/_auth/jobs/$job_id"
+    },
+    "/_auth/projects/$project_id/": {
+      "filePath": "_auth.projects.$project_id.index.tsx",
+      "parent": "/_auth/projects/$project_id"
+    },
+    "/_auth/runs/$run_barcode/": {
+      "filePath": "_auth.runs.$run_barcode.index.tsx",
+      "parent": "/_auth/runs/$run_barcode"
+    },
+    "/_auth/runs/$run_barcode/indexqc/": {
+      "filePath": "_auth.runs.$run_barcode.indexqc.index.tsx",
+      "parent": "/_auth/runs/$run_barcode/indexqc"
+    },
+    "/_auth/runs/$run_barcode/samplesheet/": {
+      "filePath": "_auth.runs.$run_barcode.samplesheet.index.tsx",
+      "parent": "/_auth/runs/$run_barcode/samplesheet"
+    }
+  }
+}
+ROUTE_MANIFEST_END */

--- a/src/routes/_auth.admin.jobs.index.tsx
+++ b/src/routes/_auth.admin.jobs.index.tsx
@@ -10,6 +10,8 @@ import { ServerDataTable } from '@/components/data-table/data-table'
 import { SortableHeader } from '@/components/data-table/sortable-header'
 import { CopyableText } from '@/components/copyable-text'
 import { FullscreenSpinner } from '@/components/spinner'
+import { ErrorState } from '@/components/error-state'
+import { ErrorBanner } from '@/components/error-banner'
 import { JobStatusBadge } from '@/components/job-status-badge'
 import { SelectFilter } from '@/components/data-table/select-filter'
 import { TextFilter } from '@/components/data-table/text-filter'
@@ -111,7 +113,7 @@ function RouteComponent() {
   })
 
   // Query jobs
-  const { data, error, isFetching } = useQuery({
+  const { data, error, isFetching, refetch } = useQuery({
     ...getJobsOptions({
       query: {
         skip: (search.page - 1) * search.per_page,
@@ -134,7 +136,7 @@ function RouteComponent() {
     navigate({ to: '/jobs/$job_id', params: { job_id: jobId } })
   }
 
-  if (error) return 'An error has occurred: ' + error.message
+  if (error && !data) return <ErrorState error={error} onRetry={() => { void refetch() }} />
   if (!data) return <FullscreenSpinner variant='ellipsis' />
 
 
@@ -252,6 +254,7 @@ function RouteComponent() {
           </p>
         </div>
       </div>
+      {error && <ErrorBanner error={error} onRetry={() => { void refetch() }} />}
       <ServerDataTable
         data={data.data}
         columns={columns}

--- a/src/routes/_auth.admin.project-settings.index.tsx
+++ b/src/routes/_auth.admin.project-settings.index.tsx
@@ -1,10 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { toast } from 'sonner'
-import type { AxiosError } from 'axios'
-import type { HttpValidationError, Setting } from '@/client'
+import type { Setting } from '@/client'
 import { getSettingsByTagOptions, getSettingsByTagQueryKey, updateSettingMutation } from '@/client/@tanstack/react-query.gen'
 import { SettingCard } from '@/components/app-setting-card'
+import { toastApiError } from '@/lib/error-utils'
 
 export const Route = createFileRoute('/_auth/admin/project-settings/')({
   component: RouteComponent,
@@ -23,10 +23,8 @@ function RouteComponent() {
   const queryClient = useQueryClient()
   const { mutate: updateSetting, isPending } = useMutation({
     ...updateSettingMutation(),
-    onError: (mutationError: AxiosError<HttpValidationError>) => {
-      const message = mutationError.response?.data.detail?.toString()
-        || "An unknown error occurred."
-      toast.error(`Failed to update setting: ${message}`)
+    onError: (mutationError) => {
+      toastApiError(mutationError, 'Failed to update setting')
     },
     onSuccess: (data: Setting) => {
       queryClient.invalidateQueries({ 

--- a/src/routes/_auth.admin.run-settings.index.tsx
+++ b/src/routes/_auth.admin.run-settings.index.tsx
@@ -1,10 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { toast } from 'sonner'
-import type { AxiosError } from 'axios'
-import type { HttpValidationError, Setting } from '@/client'
+import type { Setting } from '@/client'
 import { getSettingsByTagOptions, getSettingsByTagQueryKey, updateSettingMutation } from '@/client/@tanstack/react-query.gen'
 import { SettingCard } from '@/components/app-setting-card'
+import { toastApiError } from '@/lib/error-utils'
 
 export const Route = createFileRoute('/_auth/admin/run-settings/')({
   component: RouteComponent,
@@ -23,10 +23,8 @@ function RouteComponent() {
   const queryClient = useQueryClient()
   const { mutate: updateSetting, isPending } = useMutation({
     ...updateSettingMutation(),
-    onError: (mutationError: AxiosError<HttpValidationError>) => {
-      const message = mutationError.response?.data.detail?.toString()
-        || "An unknown error occurred."
-      toast.error(`Failed to update setting: ${message}`)
+    onError: (mutationError) => {
+      toastApiError(mutationError, 'Failed to update setting')
     },
     onSuccess: (data: Setting) => {
       queryClient.invalidateQueries({ 

--- a/src/routes/_auth.admin.vendors.index.tsx
+++ b/src/routes/_auth.admin.vendors.index.tsx
@@ -5,14 +5,16 @@ import { toast } from 'sonner'
 import z from 'zod'
 import { Plus, SquarePen, Trash2 } from 'lucide-react'
 import type { ColumnDef, PaginationState, SortingState } from '@tanstack/react-table'
-import type { AxiosError } from 'axios'
-import type { HttpValidationError, Setting, VendorPublic } from '@/client'
+import type { Setting, VendorPublic } from '@/client'
 import { deleteVendorMutation, getSettingsByTagOptions, getSettingsByTagQueryKey, getVendorsOptions, getVendorsQueryKey, updateSettingMutation } from '@/client/@tanstack/react-query.gen'
 import { ServerDataTable } from '@/components/data-table/data-table'
 import { SortableHeader } from '@/components/data-table/sortable-header'
 import { CopyableText } from '@/components/copyable-text'
 import { FullscreenSpinner } from '@/components/spinner'
+import { ErrorState } from '@/components/error-state'
+import { ErrorBanner } from '@/components/error-banner'
 import { AddVendorForm } from '@/components/add-vendor-form'
+import { toastApiError } from '@/lib/error-utils'
 import { UpdateVendorForm } from '@/components/update-vendor-form'
 import { SettingCard } from '@/components/app-setting-card'
 import { Button } from '@/components/ui/button'
@@ -73,7 +75,7 @@ function RouteComponent() {
       toast.success('Vendor deleted successfully')
     },
     onError: (error) => {
-      toast.error(`Failed to delete vendor: ${error.message}`)
+      toastApiError(error, 'Failed to delete vendor')
     }
   })
 
@@ -106,7 +108,7 @@ function RouteComponent() {
   }, [pagination, sorting])
 
   // Query vendors
-  const { data, error } = useQuery({
+  const { data, error, refetch } = useQuery({
     ...getVendorsOptions({
       query: {
         page: search.page,
@@ -119,7 +121,7 @@ function RouteComponent() {
   })
 
   // Query vendor settings
-  const { data: vendorSettings, error: settingsError } = useQuery(
+  const { data: vendorSettings, error: settingsError, refetch: refetchSettings } = useQuery(
     getSettingsByTagOptions({
       query: {
         tag_key: 'category',
@@ -131,10 +133,8 @@ function RouteComponent() {
   // Mutation for updating settings
   const { mutate: updateSetting, isPending: isSettingPending } = useMutation({
     ...updateSettingMutation(),
-    onError: (mutationError: AxiosError<HttpValidationError>) => {
-      const message = mutationError.response?.data.detail?.toString()
-        || "An unknown error occurred."
-      toast.error(`Failed to update setting: ${message}`)
+    onError: (mutationError) => {
+      toastApiError(mutationError, 'Failed to update setting')
     },
     onSuccess: (data: Setting) => {
       queryClient.invalidateQueries({ 
@@ -160,8 +160,8 @@ function RouteComponent() {
     })
   }
 
-  if (error) return 'An error has occurred: ' + error.message
-  if (settingsError) return 'An error has occurred loading settings: ' + settingsError.message
+  if (error && !data) return <ErrorState error={error} onRetry={() => { void refetch() }} />
+  if (settingsError && !vendorSettings) return <ErrorState error={settingsError} onRetry={() => { void refetchSettings() }} />
   if (!data) return <FullscreenSpinner variant='ellipsis' />
 
   // Define columns
@@ -283,6 +283,8 @@ function RouteComponent() {
           }
         />
       </div>
+      {error && <ErrorBanner error={error} onRetry={() => { void refetch() }} />}
+      {settingsError && <ErrorBanner error={settingsError} onRetry={() => { void refetchSettings() }} />}
       <ServerDataTable
         data={data.data}
         columns={columns}

--- a/src/routes/_auth.jobs.$job_id.route.tsx
+++ b/src/routes/_auth.jobs.$job_id.route.tsx
@@ -1,19 +1,13 @@
-import { AxiosError } from 'axios'
-import { Outlet, createFileRoute, redirect } from '@tanstack/react-router'
+import { Outlet, createFileRoute } from '@tanstack/react-router'
 import { getJob } from '@/client'
 
 export const Route = createFileRoute('/_auth/jobs/$job_id')({
   component: RouteComponent,
   loader: async ({ params }) => {
     const jobData = await getJob({
-      path: {
-        job_id: params.job_id
-      }
+      path: { job_id: params.job_id },
+      throwOnError: true,
     })
-    if (jobData.status !== 200 || jobData instanceof AxiosError) {
-      alert("An error occurred: " + jobData.error?.detail || "An unknown error occurred.")
-      throw redirect({ to: '/admin/jobs' })
-    }
     return ({
       crumb: jobData.data.name,
       includeCrumbLink: false,

--- a/src/routes/_auth.jobs.index.tsx
+++ b/src/routes/_auth.jobs.index.tsx
@@ -11,6 +11,8 @@ import { SortableHeader } from '@/components/data-table/sortable-header'
 import { CopyableText } from '@/components/copyable-text'
 import { JobStatusBadge } from '@/components/job-status-badge'
 import { FullscreenSpinner } from '@/components/spinner'
+import { ErrorState } from '@/components/error-state'
+import { ErrorBanner } from '@/components/error-banner'
 import { useCurrentUser } from '@/hooks/use-current-user'
 import { Button } from '@/components/ui/button'
 
@@ -47,7 +49,7 @@ function RouteComponent() {
   })
 
   // Query user-specific jobs
-  const { data: jobsData, error, isFetching } = useQuery({
+  const { data: jobsData, error, isFetching, refetch } = useQuery({
     ...getJobsOptions({
       query: {
         skip: pagination.pageIndex * pagination.pageSize,
@@ -128,7 +130,7 @@ function RouteComponent() {
     },
   ]
 
-  if (error) return 'An error has occurred: ' + error.message
+  if (error && !jobsData) return <ErrorState error={error} onRetry={() => { void refetch() }} />
   if (!jobsData) return <FullscreenSpinner variant='ellipsis' />
 
   const totalPages = Math.ceil(jobsData.count / pagination.pageSize)
@@ -157,6 +159,8 @@ function RouteComponent() {
           View and manage your submitted jobs.
         </p>
       </div>
+
+      {error && <ErrorBanner error={error} onRetry={() => { void refetch() }} />}
 
       <ServerDataTable
         data={jobsData.data}

--- a/src/routes/_auth.profile.index.tsx
+++ b/src/routes/_auth.profile.index.tsx
@@ -3,6 +3,7 @@ import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { KeyRound, Mail, ShieldCheck } from 'lucide-react'
 import { resendVerificationMutation } from '@/client/@tanstack/react-query.gen'
+import { toastApiError } from '@/lib/error-utils'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { useCurrentUser } from '@/hooks/use-current-user'
 import { ChangePasswordForm } from '@/components/change-password-form'
@@ -23,8 +24,8 @@ function RouteComponent() {
     onSuccess: () => {
       toast.success('Verification email sent. Check your inbox.')
     },
-    onError: (error: any) => {
-      toast.error(error.response?.data?.detail || 'Failed to send verification email. Please try again.')
+    onError: (error) => {
+      toastApiError(error, 'Failed to send verification email. Please try again.')
     },
   })
 

--- a/src/routes/_auth.projects.$project_id.index.tsx
+++ b/src/routes/_auth.projects.$project_id.index.tsx
@@ -12,6 +12,7 @@ import { FileBrowserDialog } from '@/components/file-browser'
 import { FileUpload } from '@/components/file-upload'
 import { ValidateManifestForm } from '@/components/validate-manifest-form'
 import { UpdateProjectForm } from '@/components/update-project-form'
+import { ErrorState } from '@/components/error-state'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -52,7 +53,7 @@ function RouteComponent() {
   }, [columnVisibility, project.project_id, setVisibility])
 
   // Fetch all samples using the use-all-paginated hook
-  const { data: allSamples, isLoading, error } = useAllPaginated({
+  const { data: allSamples, isLoading, error, refetch } = useAllPaginated({
     queryKey: ['samples', 'all', project.project_id],
     fetcher: ({ query }) => getProjectSamples({
       path: { project_id: project.project_id },
@@ -64,7 +65,7 @@ function RouteComponent() {
   })
 
   if (isLoading) return <FullscreenSpinner variant='ellipsis' />
-  if (error) return 'An error has occurred: ' + error.message
+  if (error) return <ErrorState error={error} onRetry={() => { void refetch() }} />
   if (!allSamples) return 'No data was returned.'
 
   // Since we're using client-side rendering, we need to extract unique keys from sample attributes

--- a/src/routes/_auth.projects.$project_id.route.tsx
+++ b/src/routes/_auth.projects.$project_id.route.tsx
@@ -1,6 +1,5 @@
-import { AxiosError } from 'axios'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { Outlet, createFileRoute, redirect } from '@tanstack/react-router'
+import { Outlet, createFileRoute } from '@tanstack/react-router'
 import { getProjectByProjectId } from '@/client'
 import { getProjectByProjectIdOptions } from '@/client/@tanstack/react-query.gen'
 
@@ -8,22 +7,16 @@ export const Route = createFileRoute('/_auth/projects/$project_id')({
   component: RouteComponent,
   loader: async ({ params, context }) => {
     const projectData = await getProjectByProjectId({
-      path: {
-        project_id: params.project_id
-      }
+      path: { project_id: params.project_id },
+      throwOnError: true,
     })
-    if (projectData.status !== 200 || projectData instanceof AxiosError) {
-      alert("An error occurred: " + projectData.error?.detail || "An unknown error occurred.")
-      throw redirect({ to: '/projects' })
-    }
-    
-    // Prefetch the query data
+
     await context.queryClient.prefetchQuery(
       getProjectByProjectIdOptions({
         path: { project_id: params.project_id }
       })
     )
-    
+
     return ({
       crumb: projectData.data.name || projectData.data.project_id,
       includeCrumbLink: false,

--- a/src/routes/_auth.projects.index.tsx
+++ b/src/routes/_auth.projects.index.tsx
@@ -10,6 +10,8 @@ import { SortableHeader } from '@/components/data-table/sortable-header'
 import { CopyableText } from '@/components/copyable-text'
 import { useDebounce } from '@/hooks/use-debounce';
 import { FullscreenSpinner } from '@/components/spinner';
+import { ErrorState } from '@/components/error-state';
+import { ErrorBanner } from '@/components/error-banner';
 import { highlightMatch } from '@/lib/utils';
 
 // Define the search schema for projects 
@@ -83,7 +85,7 @@ function RouteComponent() {
   }, [pagination, sorting])
 
   // Query projects
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error, refetch } = useQuery({
     ...searchProjectsOptions({
       query: {
         query: debouncedInput,
@@ -97,7 +99,7 @@ function RouteComponent() {
   })
 
   if (isLoading) return <FullscreenSpinner variant='ellipsis' />;
-  if (error) return 'An error has occurred: ' + error.message
+  if (error && !data) return <ErrorState error={error} onRetry={() => { void refetch() }} />
   if (!data) return 'No data was returned.';
 
   // Define columns
@@ -165,6 +167,11 @@ function RouteComponent() {
     <div className='animate-fade-in-up'>
       <h1 className="text-2xl">Projects</h1>
       <p className="text-muted-foreground mb-6">View all projects in NGS360</p>
+      {error && (
+        <div className="mb-4">
+          <ErrorBanner error={error} onRetry={() => { void refetch() }} />
+        </div>
+      )}
       <ServerDataTable
         data={data.data}
         columns={columns}

--- a/src/routes/_auth.runs.$run_barcode.indexqc.index.tsx
+++ b/src/routes/_auth.runs.$run_barcode.indexqc.index.tsx
@@ -1,6 +1,5 @@
-import { createFileRoute, getRouteApi, notFound, redirect } from '@tanstack/react-router'
+import { createFileRoute, getRouteApi, notFound } from '@tanstack/react-router'
 import { useState } from 'react';
-import { AxiosError } from 'axios';
 import type {ColumnDef, Row} from '@tanstack/react-table';
 import type {BarChartData} from '@/components/indexqc-barchart';
 import { CopyableText } from '@/components/copyable-text'
@@ -16,23 +15,13 @@ export const Route = createFileRoute('/_auth/runs/$run_barcode/indexqc/')({
   component: RouteComponent,
   loader: async ({ params }) => {
 
-    // Get run metrics data
+    // Get run metrics data (204 = metrics not available yet → NotFound; other errors throw)
     const res = await getRunMetrics({
-      path: {
-        run_barcode: params.run_barcode
-      }
+      path: { run_barcode: params.run_barcode },
+      throwOnError: true,
     });
 
-    if (!res.data) {
-      if (res.status === 204) throw notFound();
-      if (res instanceof AxiosError) {
-        const msg = "An error occurred: " + res.error.detail || "An unknown error occurred."
-        alert(msg)
-        throw redirect({ to: '/runs' })
-      }
-      alert('An unknown error occurred.')
-      throw redirect({ to: '/runs'})
-    }
+    if (!res.data || res.status === 204) throw notFound();
 
     return ({
       runMetrics: res.data

--- a/src/routes/_auth.runs.$run_barcode.route.tsx
+++ b/src/routes/_auth.runs.$run_barcode.route.tsx
@@ -1,6 +1,5 @@
-import { Outlet, createFileRoute, getRouteApi, redirect } from '@tanstack/react-router'
+import { Outlet, createFileRoute, getRouteApi } from '@tanstack/react-router'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { AxiosError } from 'axios'
 import { ChartBar, ChevronDown, FileSpreadsheet, FolderOpen, Loader2, PlayCircle, RotateCw, Upload } from 'lucide-react'
 import { useRef, useState } from 'react'
 import { toast } from 'sonner'
@@ -8,6 +7,7 @@ import type { ChangeEvent } from 'react';
 import type { DemuxWorkflowConfig } from '@/client'
 import { getDemultiplexWorkflowConfig, getRun, listDemultiplexWorkflows } from '@/client'
 import { getRunQueryKey, getRunSamplesheetQueryKey, postRunSamplesheetMutation, updateRunMutation } from '@/client/@tanstack/react-query.gen'
+import { ErrorBanner } from '@/components/error-banner'
 import { ExecuteToolForm } from '@/components/execute-demux-job-form'
 import { TabLink, TabNav } from '@/components/tab-nav'
 import { Button } from '@/components/ui/button'
@@ -15,6 +15,7 @@ import { Separator } from '@/components/ui/separator'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { FileBrowserDialog } from '@/components/file-browser';
 import { FullscreenSpinner } from '@/components/spinner'
+import { toastApiError } from '@/lib/error-utils'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -25,17 +26,10 @@ import {
 export const Route = createFileRoute('/_auth/runs/$run_barcode')({
   component: RouteComponent,
   loader: async ({ params }) => {
-    // Get run data
     const runData = await getRun({
-      path: {
-        run_barcode: params.run_barcode
-      }
+      path: { run_barcode: params.run_barcode },
+      throwOnError: true,
     })
-    if (runData.status !== 200 || runData instanceof AxiosError) {
-      alert("An error occurred: " + runData.error?.detail || "An unknown error occurred.")
-      throw redirect({ to: '/runs' })
-    }
-
     return ({
       crumb: runData.data.barcode,
       includeCrumbLink: false,
@@ -96,7 +90,7 @@ function RouteComponent() {
       setToolDialogOpen(true)
     } catch (error) {
       console.error('Error fetching workflow config:', error)
-      toast.error(`Failed to fetch config for workflow: ${workflow}`)
+      toastApiError(error, `Failed to fetch config for workflow: ${workflow}`)
     }
     setDropdownOpen(false)
   }
@@ -117,7 +111,7 @@ function RouteComponent() {
     },
     onError: (uploadError) => {
       console.error(uploadError);
-      toast.error('Failed to upload file');
+      toastApiError(uploadError, 'Failed to upload file');
     }
   })
 
@@ -135,7 +129,7 @@ function RouteComponent() {
     },
     onError: (updateError) => {
       console.error(updateError)
-      toast.error('Failed to re-sync run')
+      toastApiError(updateError, 'Failed to re-sync run')
     }
   })
 
@@ -294,14 +288,25 @@ function RouteComponent() {
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
-                    {toolsQuery.data?.map((tool) => (
-                      <DropdownMenuItem
-                        key={tool}
-                        onClick={() => handleToolSelect(tool)}
-                      >
-                        {tool}
-                      </DropdownMenuItem>
-                    ))}
+                    {toolsQuery.isError ? (
+                      <div className="p-1 w-80 max-w-[min(20rem,calc(100vw-2rem))]">
+                        <ErrorBanner
+                          error={toolsQuery.error}
+                          onRetry={() => { void toolsQuery.refetch() }}
+                        />
+                      </div>
+                    ) : toolsQuery.data && toolsQuery.data.length === 0 ? (
+                      <DropdownMenuItem disabled>No tools available</DropdownMenuItem>
+                    ) : (
+                      toolsQuery.data?.map((tool) => (
+                        <DropdownMenuItem
+                          key={tool}
+                          onClick={() => handleToolSelect(tool)}
+                        >
+                          {tool}
+                        </DropdownMenuItem>
+                      ))
+                    )}
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>

--- a/src/routes/_auth.runs.$run_barcode.samplesheet.index.tsx
+++ b/src/routes/_auth.runs.$run_barcode.samplesheet.index.tsx
@@ -1,9 +1,8 @@
-import { Link, createFileRoute, getRouteApi, useNavigate } from '@tanstack/react-router'
+import { Link, createFileRoute, getRouteApi } from '@tanstack/react-router'
 import { createColumnHelper } from '@tanstack/react-table'
 import { useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import { toast } from 'sonner'
-import { AxiosError } from 'axios'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import type { IlluminaSampleSheetResponseModel as RunSamplesheet } from '@/client/types.gen'
 import { ClientDataTable } from '@/components/data-table/data-table'
 import { SortableHeader } from '@/components/data-table/sortable-header'
@@ -11,7 +10,9 @@ import { CopyableText } from '@/components/copyable-text'
 import { FullscreenDropzone } from '@/components/file-upload'
 import { NotFoundComponent } from '@/components/samplesheet-not-found-component'
 import { getRunSamplesheetOptions, getRunSamplesheetQueryKey, postRunSamplesheetMutation } from '@/client/@tanstack/react-query.gen'
+import { ErrorState } from '@/components/error-state'
 import { FullscreenSpinner } from '@/components/spinner'
+import { toastApiError } from '@/lib/error-utils'
 import { highlightMatch } from '@/lib/utils'
 
 export const Route = createFileRoute('/_auth/runs/$run_barcode/samplesheet/')({
@@ -24,14 +25,13 @@ function RouteComponent() {
   // Get route params
   const routeApi = getRouteApi('/_auth/runs/$run_barcode/samplesheet/')
   const { run_barcode } = routeApi.useParams()
-  const navigate = useNavigate()
   const queryClient = useQueryClient();
   
   // Global filter for search
   const [globalFilter, setGlobalFilter] = useState<string>('')
   
   // Use TanStack Query to fetch samplesheet data with custom error handling
-  const { data: runInfo, isLoading, error, isError } = useQuery({
+  const { data: runInfo, isLoading, error, isError, refetch } = useQuery({
     ...getRunSamplesheetOptions({
       path: {
         run_barcode: run_barcode
@@ -57,6 +57,7 @@ function RouteComponent() {
     },
     onError: (uploadError) => {
       console.error(uploadError);
+      toastApiError(uploadError, 'Failed to upload samplesheet');
     }
   })
 
@@ -76,44 +77,24 @@ function RouteComponent() {
     }
   }, [mutate, run_barcode])
 
-  // Handle redirects and alerts for specific error cases
-  useEffect(() => {
-    if (isError) {
-      // Handle AxiosError cases - redirect to /runs with alert
-      if (error instanceof AxiosError) {
-        const msg = "An error occurred: " + (error.response?.data?.detail || error.message || "An unknown error occurred.")
-        alert(msg)
-        navigate({ to: '/runs' })
-        return
-      }
-      
-      // Handle other non-404/204 errors
-      if ((error as any).status !== 404 && (error as any).status !== 204) {
-        alert('An unknown error occurred.')
-        navigate({ to: '/runs' })
-        return
-      }
-    }
-  }, [isError, error, navigate])
-
   // Show loading spinner
   if (isLoading || isPending) {
     return <FullscreenSpinner variant='ellipsis' />
   }
 
-  // Show not found component for 204 status or when no data
-  if (isError && ((error as any).status === 204 || (error as any).status === 404)) {
-    return <NotFoundComponent />
-  }
-  
-  // Show not found component if no data but no error (edge case)
-  if (!runInfo && !isError) {
+  // Show not found component for 204 status or when no data (missing samplesheet is expected)
+  if (isError && ((error as any).response?.status === 404 || (error as any).response?.status === 204)) {
     return <NotFoundComponent />
   }
 
-  // If we still have an error at this point, the useEffect should handle it
+  // Any other error: surface via ErrorState with retry
   if (isError) {
-    return <FullscreenSpinner variant='ellipsis' /> // Show spinner while redirect happens
+    return <ErrorState error={error} onRetry={() => { void refetch() }} />
+  }
+
+  // Show not found component if no data but no error (edge case)
+  if (!runInfo) {
+    return <NotFoundComponent />
   }
 
   // Transform header, reads, and settings 

--- a/src/routes/_auth.runs.index.tsx
+++ b/src/routes/_auth.runs.index.tsx
@@ -10,6 +10,8 @@ import { SortableHeader } from '@/components/data-table/sortable-header'
 import { CopyableText } from '@/components/copyable-text'
 import { useDebounce } from '@/hooks/use-debounce';
 import { FullscreenSpinner } from '@/components/spinner';
+import { ErrorState } from '@/components/error-state';
+import { ErrorBanner } from '@/components/error-banner';
 import { highlightMatch } from '@/lib/utils';
 
 // Define the search schema for projects 
@@ -84,7 +86,7 @@ function RouteComponent() {
   }, [pagination, sorting])
 
   // Query runs
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error, refetch } = useQuery({
     ...searchRunsOptions({
       query: {
         query: debouncedInput,
@@ -98,7 +100,7 @@ function RouteComponent() {
   })
 
   if (isLoading) return <FullscreenSpinner variant='ellipsis' />;
-  if (error) return 'An error has occurred: ' + error.message
+  if (error && !data) return <ErrorState error={error} onRetry={() => { void refetch() }} />
   if (!data) return 'No data was returned.';
 
   // Define columns
@@ -195,6 +197,11 @@ function RouteComponent() {
     <div className='animate-fade-in-up'>
       <h1 className="text-2xl">Illumina Runs</h1>
       <p className="text-muted-foreground mb-6">View all illumina runs in NGS360</p>
+      {error && (
+        <div className="mb-4">
+          <ErrorBanner error={error} onRetry={() => { void refetch() }} />
+        </div>
+      )}
       <ServerDataTable
         data={data.data}
         columns={columns}

--- a/src/routes/_user.verify-email.tsx
+++ b/src/routes/_user.verify-email.tsx
@@ -5,6 +5,7 @@ import { CheckCircle2, LoaderCircle, Mail, XCircle } from 'lucide-react'
 import { verifyEmailMutation } from '@/client/@tanstack/react-query.gen'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { getFormApiErrorMessage } from '@/lib/error-utils'
 
 // Define the search schema for email verification
 const verifyEmailSearchSchema = z.object({
@@ -80,7 +81,7 @@ function RouteComponent() {
                 <div>
                   <h3 className="text-lg font-semibold mb-2">Verification Failed</h3>
                   <p className="text-muted-foreground">
-                    {error.message || 'The verification token is invalid or has expired. Please request a new verification email.'}
+                    {getFormApiErrorMessage(error, 'The verification token is invalid or has expired. Please request a new verification email.')}
                   </p>
                 </div>
                 <Button asChild className="w-full" variant="outline">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary
- Introduces a single error-handling system used consistently across the app. `classifyError` maps 400/401/403/404/409/422/429/502/503/504 to specific titles and descriptions, preferring backend `detail` when present; `getTechnicalDetail` renders `HTTP <status> from <METHOD> <url>` so the technical-details panel describes the backend exchange instead of the JS stack.
- `ErrorState` (page), `ErrorBanner` (inline, with collapsible technical details), `toastApiError` (mutations), and `getFormApiErrorMessage` (react-hook-form roots) now share a common palette keyed on `ErrorKind`. Existing call sites across admin, auth, project, run, job, and samplesheet flows have been migrated off hand-rolled error JSX, `alert()` + redirect loops, and raw `error.message` / `error.response?.data.detail?.toString()` patterns.
- Route loaders for `/projects/$id`, `/runs/$barcode`, and `/jobs/$id` use `throwOnError: true`, letting the global `DefaultErrorComponent` render `ErrorState` and keeping hover preloads silent. Samplesheet and IndexQC tabs use `ErrorState`; 404/204 still render the NotFound fallback. Toaster uses `richColors` with popover-bg + `--destructive` text so error toasts are visually distinct without being overwhelming. Fixes a null-safety bug in `extractDetail` that crashed on bodyless error responses.