### PR TITLE
Make all sequencing run table columns sortable

### DIFF
--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -215,7 +215,6 @@ export type ActionSubmitRequest = {
 
 /**
  * Attribute
- * Reusable key-value pair for request/response payloads.
  */
 export type Attribute = {
   /**
@@ -1468,7 +1467,7 @@ export type PipelineCreate = {
   /**
    * Attributes
    */
-  attributes?: Array<Attribute> | null
+  attributes?: Array<ApiWorkflowModelsAttribute> | null
   /**
    * Workflow Ids
    */
@@ -1502,7 +1501,7 @@ export type PipelinePublic = {
   /**
    * Attributes
    */
-  attributes?: Array<Attribute> | null
+  attributes?: Array<ApiWorkflowModelsAttribute> | null
   /**
    * Workflows
    */
@@ -1979,7 +1978,7 @@ export type SampleCreate = {
   /**
    * Attributes
    */
-  attributes?: Array<ApiSamplesModelsAttribute> | null
+  attributes?: Array<Attribute> | null
   /**
    * Run Id
    */
@@ -2080,7 +2079,7 @@ export type SamplePublic = {
   /**
    * Attributes
    */
-  attributes: Array<ApiSamplesModelsAttribute> | null
+  attributes: Array<Attribute> | null
   /**
    * Run Id
    */
@@ -2139,7 +2138,7 @@ export type SampleWithFilesPublic = {
   /**
    * Attributes
    */
-  attributes: Array<ApiSamplesModelsAttribute> | null
+  attributes: Array<Attribute> | null
   /**
    * Run Id
    */
@@ -2722,7 +2721,7 @@ export type WorkflowCreate = {
   /**
    * Attributes
    */
-  attributes?: Array<Attribute> | null
+  attributes?: Array<ApiWorkflowModelsAttribute> | null
 }
 
 /**
@@ -2756,7 +2755,7 @@ export type WorkflowPublic = {
   /**
    * Attributes
    */
-  attributes?: Array<Attribute> | null
+  attributes?: Array<ApiWorkflowModelsAttribute> | null
   /**
    * Registrations
    */
@@ -2826,7 +2825,7 @@ export type WorkflowRunCreate = {
   /**
    * Attributes
    */
-  attributes?: Array<Attribute> | null
+  attributes?: Array<ApiWorkflowModelsAttribute> | null
 }
 
 /**
@@ -2864,7 +2863,7 @@ export type WorkflowRunPublic = {
   /**
    * Attributes
    */
-  attributes?: Array<Attribute> | null
+  attributes?: Array<ApiWorkflowModelsAttribute> | null
 }
 
 /**
@@ -2937,8 +2936,9 @@ export type ApiProjectModelsAttribute = {
 
 /**
  * Attribute
+ * Reusable key-value pair for request/response payloads.
  */
-export type ApiSamplesModelsAttribute = {
+export type ApiWorkflowModelsAttribute = {
   /**
    * Key
    */
@@ -4598,7 +4598,7 @@ export type BulkCreateSamplesResponse =
   BulkCreateSamplesResponses[keyof BulkCreateSamplesResponses]
 
 export type UpdateSampleInProjectData = {
-  body: ApiSamplesModelsAttribute
+  body: Attribute
   path: {
     /**
      * Sample Id
@@ -4980,7 +4980,7 @@ export type SearchRunsData = {
      * Sort By
      * Field to sort by
      */
-    sort_by?: ('run_id' | 'experiment_name') | null
+    sort_by?: string | null
     /**
      * Sort Order
      * Sort order (asc or desc)

--- a/src/routes/_auth.runs.index.tsx
+++ b/src/routes/_auth.runs.index.tsx
@@ -17,10 +17,7 @@ const runsSearchSchema = z.object({
   query: z.string().optional().default(""),
   page: z.number().optional().default(1),
   per_page: z.number().optional().default(10),
-  sort_by: z.union([
-    z.literal('run_id'),
-    z.literal('experiment_name')
-  ]).optional().default('run_id'),
+  sort_by: z.string().optional().default('run_date'),
   sort_order: z.union([
     z.literal('asc'),
     z.literal('desc')
@@ -52,7 +49,7 @@ function RouteComponent() {
     pageSize: search.per_page
   });
 
-  // Sorting (default: barcode desc)
+  // Sorting (default: run_date desc)
   const [sorting, setSorting] = useState<SortingState>([
     { id: search.sort_by, desc: search.sort_order == 'desc' ? true : false }
   ]);
@@ -76,7 +73,7 @@ function RouteComponent() {
         ...search,
         page: pagination.pageIndex + 1,
         per_page: pagination.pageSize,
-        sort_by: sorting[0]?.id as 'run_id' | 'experiment_name',
+        sort_by: sorting[0]?.id ?? 'run_date',
         sort_order: sorting[0]?.desc ? 'desc' : 'asc'
       },
       replace: true
@@ -137,7 +134,7 @@ function RouteComponent() {
     {
       accessorKey: 'machine_id',
       meta: { alias: "Instrument" },
-      header: "Instrument",
+      header: ({ column }) => <SortableHeader column={column} name="Instrument" />,
       cell: ({ cell }) => {
         const value = cell.getValue() as string
         return (
@@ -152,7 +149,7 @@ function RouteComponent() {
     {
       accessorKey: 'flowcell_id',
       meta: { alias: "Flowcell" },
-      header: "Flowcell",
+      header: ({ column }) => <SortableHeader column={column} name="Flowcell" />,
       cell: ({ cell }) => {
         const value = cell.getValue() as string
         return (
@@ -167,12 +164,12 @@ function RouteComponent() {
     {
       accessorKey: 'run_date',
       meta: { alias: "Run Date" },
-      header: "Run Date"
+      header: ({ column }) => <SortableHeader column={column} name="Run Date" />
     },
     {
       accessorKey: 'run_folder_uri',
       meta: { alias: "Run Folder" },
-      header: "Run Folder",
+      header: ({ column }) => <SortableHeader column={column} name="Run Folder" />,
       cell: ({ cell }) => {
         const value = cell.getValue() as string
         return (
@@ -187,7 +184,7 @@ function RouteComponent() {
     {
       accessorKey: 'status',
       meta: { alias: "Status" },
-      header: "Status"
+      header: ({ column }) => <SortableHeader column={column} name="Status" />
     }
   ]
 


### PR DESCRIPTION
Widen SearchRuns sort_by to accept any field (regenerated client) and wrap every column header in the runs table with SortableHeader. Default sort changes to run_date desc.

Fixes #61 