### PR TITLE
Sample table cell editing (draft — needs polish)

### DIFF
--- a/src/components/data-table/data-table.tsx
+++ b/src/components/data-table/data-table.tsx
@@ -10,6 +10,7 @@ import type { ColumnDef, OnChangeFn, PaginationState, Table as ReactTable, Row, 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area"
 import { DataTablePagination } from "@/components/data-table/pagination";
+import { useSkipper } from "@/components/data-table/use-skipper";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ContainedSpinner } from "@/components/spinner";
@@ -428,11 +429,17 @@ export function ClientDataTable<TData, TValue>({
     [columns, enableRowSelectionColumn, gutterColumnSpec]
   );
 
+  // Opt-in skip for in-place data edits (e.g. inline cell edits) so they
+  // don't snap the user back to page 1, while filter/sort changes still
+  // reset normally.
+  const [autoResetPageIndex, skipAutoResetPageIndex] = useSkipper()
+
   const table = useReactTable({
     data,
     columns: columnsWithFilter,
     enableRowSelection: enableRowSelectionColumn,
-    autoResetPageIndex: false,
+    autoResetPageIndex,
+    meta: { skipAutoResetPageIndex },
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/src/components/data-table/data-table.tsx
+++ b/src/components/data-table/data-table.tsx
@@ -432,6 +432,7 @@ export function ClientDataTable<TData, TValue>({
     data,
     columns: columnsWithFilter,
     enableRowSelection: enableRowSelectionColumn,
+    autoResetPageIndex: false,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/src/components/data-table/editable-cell.tsx
+++ b/src/components/data-table/editable-cell.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react'
+import type { ReactNode } from 'react'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+
+interface EditableCellProps {
+  value: string | undefined
+  /**
+   * Persist the new value. Receives the trimmed input, or `null` when the
+   * input is empty. Must throw / reject on failure so the cell knows to keep
+   * edit mode open. Side effects like toasts are the caller's responsibility.
+   */
+  onSave: (newValue: string | null) => Promise<unknown>
+  /**
+   * Display-mode content. The caller is responsible for attaching the
+   * provided `enterEdit` handler to the clickable element.
+   */
+  renderDisplay: (props: { enterEdit: () => void }) => ReactNode
+  inputClassName?: string
+}
+
+export function EditableCell({
+  value,
+  onSave,
+  renderDisplay,
+  inputClassName,
+}: EditableCellProps) {
+  const [isEditing, setIsEditing] = useState(false)
+  const [draft, setDraft] = useState(value ?? '')
+  const [isPending, setIsPending] = useState(false)
+
+  // Reflect upstream value changes (e.g. after a refetch) into the draft
+  // while not actively editing.
+  useEffect(() => {
+    if (!isEditing) setDraft(value ?? '')
+  }, [value, isEditing])
+
+  const enterEdit = () => {
+    setDraft(value ?? '')
+    setIsEditing(true)
+  }
+
+  const commit = async () => {
+    if (isPending) return
+    const trimmed = draft.trim()
+    const original = (value ?? '').trim()
+    if (trimmed === original) {
+      setIsEditing(false)
+      return
+    }
+    setIsPending(true)
+    try {
+      await onSave(trimmed === '' ? null : trimmed)
+      setIsEditing(false)
+    } catch {
+      // Caller surfaces the error (e.g. via toast). Keep edit mode open
+      // so the user can retry or hit Escape.
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  if (isEditing) {
+    return (
+      <Input
+        autoFocus
+        value={draft}
+        disabled={isPending}
+        aria-busy={isPending}
+        onChange={(e) => setDraft(e.target.value)}
+        onFocus={(e) => e.currentTarget.select()}
+        onBlur={() => void commit()}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            void commit()
+          } else if (e.key === 'Escape') {
+            e.preventDefault()
+            setDraft(value ?? '')
+            setIsEditing(false)
+          }
+        }}
+        className={cn('h-8', inputClassName)}
+      />
+    )
+  }
+
+  return <>{renderDisplay({ enterEdit })}</>
+}

--- a/src/components/data-table/use-skipper.ts
+++ b/src/components/data-table/use-skipper.ts
@@ -1,0 +1,26 @@
+import { useCallback, useEffect, useRef } from 'react'
+import type { RowData } from '@tanstack/react-table'
+
+/**
+ * TanStack's recommended pattern for selectively opting out of
+ * `autoResetPageIndex`. Pass the returned boolean as `autoResetPageIndex`
+ * and call `skip()` immediately before an in-place data change you do *not*
+ * want to reset the page (e.g. an inline cell edit). Filter and sort
+ * changes still reset normally.
+ */
+export function useSkipper(): readonly [boolean, () => void] {
+  const shouldResetRef = useRef(true)
+  const skip = useCallback(() => {
+    shouldResetRef.current = false
+  }, [])
+  useEffect(() => {
+    shouldResetRef.current = true
+  })
+  return [shouldResetRef.current, skip] as const
+}
+
+declare module '@tanstack/react-table' {
+  interface TableMeta<TData extends RowData> {
+    skipAutoResetPageIndex?: () => void
+  }
+}

--- a/src/components/editable-metadata-cell.tsx
+++ b/src/components/editable-metadata-cell.tsx
@@ -1,0 +1,74 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import type { InfiniteData } from '@tanstack/react-query'
+import type { SamplePublic } from '@/client/types.gen'
+import type { PaginatedResponse } from '@/hooks/use-all-paginated'
+import { CopyableText } from '@/components/copyable-text'
+import { EditableCell } from '@/components/data-table/editable-cell'
+import { highlightMatch } from '@/lib/utils'
+import { toastApiError } from '@/lib/error-utils'
+import { updateSampleInProjectMutation } from '@/client/@tanstack/react-query.gen'
+
+type SamplesInfiniteData = InfiniteData<PaginatedResponse<SamplePublic>>
+
+interface EditableMetadataCellProps {
+  projectId: string
+  sampleId: string
+  attributeKey: string
+  value: string | undefined
+  globalFilter: string
+}
+
+export function EditableMetadataCell({
+  projectId,
+  sampleId,
+  attributeKey,
+  value,
+  globalFilter,
+}: EditableMetadataCellProps) {
+  const queryClient = useQueryClient()
+
+  const { mutateAsync } = useMutation({
+    ...updateSampleInProjectMutation(),
+    onSuccess: (updated) => {
+      queryClient.setQueriesData<SamplesInfiniteData>(
+        { queryKey: ['samples', 'all', projectId] },
+        (old) => old && {
+          ...old,
+          pages: old.pages.map((page) => ({
+            ...page,
+            data: page.data.map((s) => s.sample_id === updated.sample_id ? updated : s),
+          })),
+        },
+      )
+      toast.success(`Updated ${attributeKey} for sample ${sampleId} in project ${projectId}`)
+    },
+    onError: (error) => {
+      toastApiError(error, `Failed to update ${attributeKey} for sample ${sampleId} in project ${projectId}`)
+    },
+  })
+
+  return (
+    <EditableCell
+      value={value}
+      onSave={(newValue) => mutateAsync({
+        path: { project_id: projectId, sample_id: sampleId },
+        // Backend column is NOT NULL — send empty string for cleared values.
+        body: { key: attributeKey, value: newValue ?? '' },
+      })}
+      renderDisplay={({ enterEdit }) =>
+        value ? (
+          <CopyableText text={value} variant='hover' asChild>
+            <span onClick={enterEdit} className='truncate min-w-0 cursor-text'>
+              {highlightMatch(value, globalFilter)}
+            </span>
+          </CopyableText>
+        ) : (
+          <span onClick={enterEdit} className='text-muted-foreground italic cursor-text'>
+            Not found
+          </span>
+        )
+      }
+    />
+  )
+}

--- a/src/components/editable-metadata-cell.tsx
+++ b/src/components/editable-metadata-cell.tsx
@@ -17,6 +17,7 @@ interface EditableMetadataCellProps {
   attributeKey: string
   value: string | undefined
   globalFilter: string
+  skipAutoResetPageIndex?: () => void
 }
 
 export function EditableMetadataCell({
@@ -25,12 +26,14 @@ export function EditableMetadataCell({
   attributeKey,
   value,
   globalFilter,
+  skipAutoResetPageIndex,
 }: EditableMetadataCellProps) {
   const queryClient = useQueryClient()
 
   const { mutateAsync } = useMutation({
     ...updateSampleInProjectMutation(),
     onSuccess: (updated) => {
+      skipAutoResetPageIndex?.()
       queryClient.setQueriesData<SamplesInfiniteData>(
         { queryKey: ['samples', 'all', projectId] },
         (old) => old && {

--- a/src/routes/_auth.projects.$project_id.index.tsx
+++ b/src/routes/_auth.projects.$project_id.index.tsx
@@ -9,6 +9,7 @@ import type { SampleDiffResult } from '@/lib/sample-diff'
 import { classifyBulkUploadItems } from '@/lib/sample-diff'
 import { TableDiffBanner } from '@/components/data-table/table-diff-banner'
 import { CopyableText } from '@/components/copyable-text'
+import { EditableMetadataCell } from '@/components/editable-metadata-cell'
 import { ClientDataTable } from '@/components/data-table/data-table'
 import { SortableHeader } from '@/components/data-table/sortable-header'
 import { ExecuteActionForm } from '@/components/execute-action-form'
@@ -257,11 +258,18 @@ function RouteComponent() {
       id: colName,
       accessorFn: (row) => row.attributes?.find((a) => a.key === colName)?.value,
       header: ({ column }) => <SortableHeader column={column} name={colName} />,
-      cell: ({ getValue, table }) => {
+      cell: ({ getValue, row, table }) => {
         const value = getValue() as string | undefined
-        if (!value) return <span className='text-muted-foreground italic'>Not found</span>
         const filter = (table.getState().globalFilter as string | undefined) ?? ''
-        return <CopyableText text={value} variant='hover' children={highlightMatch(value, filter)} />
+        return (
+          <EditableMetadataCell
+            projectId={row.original.project_id}
+            sampleId={row.original.sample_id}
+            attributeKey={colName}
+            value={value}
+            globalFilter={filter}
+          />
+        )
       },
     }))
 

--- a/src/routes/_auth.projects.$project_id.index.tsx
+++ b/src/routes/_auth.projects.$project_id.index.tsx
@@ -268,6 +268,7 @@ function RouteComponent() {
             attributeKey={colName}
             value={value}
             globalFilter={filter}
+            skipAutoResetPageIndex={table.options.meta?.skipAutoResetPageIndex}
           />
         )
       },


### PR DESCRIPTION
## Summary
- Adds inline editing for sample metadata cells (click cell, Enter/blur saves, Escape cancels).
- Implements the `useSkipper` pattern so in-cell edits don't reset pagination to page 1.

## Status
Draft. Originally merged via PR #62 but reverted in `846b653` because the feature needs additional work before shipping. Branch was rebased onto post-revert staging so it can be merged cleanly when ready.
