### PR TITLE
Gate job log fetch on job status and log_stream_name

### DIFF
--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -1646,7 +1646,7 @@ export type ProjectCreate = {
   /**
    * Attributes
    */
-  attributes?: Array<ApiProjectModelsAttribute> | null
+  attributes?: Array<Attribute> | null
 }
 
 /**
@@ -1672,7 +1672,7 @@ export type ProjectPublic = {
   /**
    * Attributes
    */
-  attributes: Array<ApiProjectModelsAttribute> | null
+  attributes: Array<Attribute> | null
   /**
    * Sequencing Runs
    */
@@ -1691,7 +1691,7 @@ export type ProjectUpdate = {
   /**
    * Attributes
    */
-  attributes?: Array<ApiProjectModelsAttribute> | null
+  attributes?: Array<Attribute> | null
 }
 
 /**
@@ -2025,7 +2025,7 @@ export type SampleCreate = {
   /**
    * Attributes
    */
-  attributes?: Array<Attribute> | null
+  attributes?: Array<ApiSamplesModelsAttribute> | null
   /**
    * Run Id
    */
@@ -2126,7 +2126,7 @@ export type SamplePublic = {
   /**
    * Attributes
    */
-  attributes: Array<Attribute> | null
+  attributes: Array<ApiSamplesModelsAttribute> | null
   /**
    * Run Id
    */
@@ -2185,7 +2185,7 @@ export type SampleWithFilesPublic = {
   /**
    * Attributes
    */
-  attributes: Array<Attribute> | null
+  attributes: Array<ApiSamplesModelsAttribute> | null
   /**
    * Run Id
    */
@@ -2916,6 +2916,10 @@ export type WorkflowVersionCreate = {
    * Definition Uri
    */
   definition_uri: string
+  /**
+   * Attributes
+   */
+  attributes?: Array<ApiWorkflowModelsAttribute> | null
 }
 
 /**
@@ -2950,6 +2954,10 @@ export type WorkflowVersionPublic = {
    * Deployments
    */
   deployments?: Array<WorkflowDeploymentPublic> | null
+  /**
+   * Attributes
+   */
+  attributes?: Array<ApiWorkflowModelsAttribute> | null
 }
 
 /**
@@ -2978,7 +2986,7 @@ export type WorkflowVersionSummary = {
 /**
  * Attribute
  */
-export type ApiProjectModelsAttribute = {
+export type ApiSamplesModelsAttribute = {
   /**
    * Key
    */
@@ -4781,7 +4789,7 @@ export type DeleteSampleFromProjectResponse =
   DeleteSampleFromProjectResponses[keyof DeleteSampleFromProjectResponses]
 
 export type UpdateSampleInProjectData = {
-  body: Attribute
+  body: ApiSamplesModelsAttribute
   path: {
     /**
      * Sample Id

--- a/src/hooks/use-job-log.ts
+++ b/src/hooks/use-job-log.ts
@@ -31,7 +31,7 @@ const INDICATOR_THRESHOLD_RATIO = 0.20
 //     - Shows "Scroll to load more" indicator near the bottom
 // --------------------------------------------------------------------------
 
-export function useJobLog(jobId: string, isLive: boolean) {
+export function useJobLog(jobId: string, isLive: boolean, enabled: boolean) {
   const queryClient = useQueryClient()
 
   // ── Query setup ──────────────────────────────────────────────────────
@@ -63,6 +63,7 @@ export function useJobLog(jobId: string, isLive: boolean) {
     string | undefined
   >({
     queryKey,
+    enabled,
     queryFn: async ({ pageParam, signal }) => {
       const { data: logData } = await getJobLogPaginated({
         path: { job_id: jobId },

--- a/src/routes/_auth.jobs.$job_id.index.tsx
+++ b/src/routes/_auth.jobs.$job_id.index.tsx
@@ -32,6 +32,9 @@ function RouteComponent() {
   })
 
   const isLive = job.status === 'RUNNING'
+  const hasLog =
+    ['RUNNING', 'SUCCEEDED', 'FAILED'].includes(job.status) &&
+    !!job.log_stream_name
 
   const {
     lines,
@@ -41,7 +44,7 @@ function RouteComponent() {
     isFetchingNextPage,
     isNearBottom,
     scrollAreaRef,
-  } = useJobLog(job.id, isLive)
+  } = useJobLog(job.id, isLive, hasLog)
 
   const jobLogText = lines
     .map((line, index) => `${index + 1}: ${line}`)
@@ -150,7 +153,9 @@ function RouteComponent() {
         <CardContent>
           <div className="relative">
             <ScrollArea ref={scrollAreaRef} className="h-[500px] rounded-lg border border-border bg-muted">
-              {jobLogStatus === 'pending' ? (
+              {!hasLog ? (
+                <div className="p-4 text-sm text-muted-foreground">No job log output is available yet.</div>
+              ) : jobLogStatus === 'pending' ? (
                 <div className="p-4 text-sm text-muted-foreground">Loading job log...</div>
               ) : jobLogError ? (
                 <div className="p-4 text-sm text-destructive">Failed to load job log: {jobLogErrorMessage}</div>


### PR DESCRIPTION
The log panel showed a 404 error for jobs that had not yet started. Skip the fetch until the job has reached a state where AWS Batch has provisioned a log stream and show a placeholder instead.

Fixes #70