### PR TITLE
Remove project_id from sample metadata TSV download

### DIFF
--- a/src/client/@tanstack/react-query.gen.ts
+++ b/src/client/@tanstack/react-query.gen.ts
@@ -70,8 +70,8 @@ import {
   getWorkflowById,
   getWorkflowDeployments,
   getWorkflowDeploymentsForWorkflow,
+  getWorkflowVersion,
   getWorkflowVersionAliases,
-  getWorkflowVersionById,
   getWorkflowVersions,
   getWorkflows,
   healthCheck,
@@ -243,7 +243,7 @@ import type {
   GetWorkflowDeploymentsData,
   GetWorkflowDeploymentsForWorkflowData,
   GetWorkflowVersionAliasesData,
-  GetWorkflowVersionByIdData,
+  GetWorkflowVersionData,
   GetWorkflowVersionsData,
   GetWorkflowsData,
   GetWorkflowsError,
@@ -283,7 +283,6 @@ import type {
   RegisterError,
   RegisterResponse,
   ReindexProjectsData,
-  ReindexProjectsResponse,
   ReindexRunsData,
   ReindexSamplesData,
   RemoveSampleFromRunData,
@@ -2920,12 +2919,12 @@ export const reindexProjectsOptions = (
 export const reindexProjectsMutation = (
   options?: Partial<Options<ReindexProjectsData>>,
 ): UseMutationOptions<
-  ReindexProjectsResponse,
+  unknown,
   AxiosError<DefaultError>,
   Options<ReindexProjectsData>
 > => {
   const mutationOptions: UseMutationOptions<
-    ReindexProjectsResponse,
+    unknown,
     AxiosError<DefaultError>,
     Options<ReindexProjectsData>
   > = {
@@ -3043,6 +3042,9 @@ export const getProjectSamplesQueryKey = (
  * Pagination is offset-based: ``skip`` is the number of records to skip
  * and ``limit`` caps the page size. Pass ``?include=files`` to eagerly
  * load file metadata for each sample.
+ *
+ * By default only the latest version of each file (by URI) is returned.
+ * Pass ``?file_versions=all`` to include all versions.
  */
 export const getProjectSamplesOptions = (
   options: Options<GetProjectSamplesData>,
@@ -5163,20 +5165,20 @@ export const createWorkflowVersionMutation = (
   return mutationOptions
 }
 
-export const getWorkflowVersionByIdQueryKey = (
-  options: Options<GetWorkflowVersionByIdData>,
-) => createQueryKey('getWorkflowVersionById', options)
+export const getWorkflowVersionQueryKey = (
+  options: Options<GetWorkflowVersionData>,
+) => createQueryKey('getWorkflowVersion', options)
 
 /**
- * Get Workflow Version By Id
+ * Get Workflow Version
  * Get a specific workflow version.
  */
-export const getWorkflowVersionByIdOptions = (
-  options: Options<GetWorkflowVersionByIdData>,
+export const getWorkflowVersionOptions = (
+  options: Options<GetWorkflowVersionData>,
 ) => {
   return queryOptions({
     queryFn: async ({ queryKey, signal }) => {
-      const { data } = await getWorkflowVersionById({
+      const { data } = await getWorkflowVersion({
         ...options,
         ...queryKey[0],
         signal,
@@ -5184,7 +5186,7 @@ export const getWorkflowVersionByIdOptions = (
       })
       return data
     },
-    queryKey: getWorkflowVersionByIdQueryKey(options),
+    queryKey: getWorkflowVersionQueryKey(options),
   })
 }
 

--- a/src/client/sdk.gen.ts
+++ b/src/client/sdk.gen.ts
@@ -190,9 +190,9 @@ import type {
   GetWorkflowVersionAliasesData,
   GetWorkflowVersionAliasesErrors,
   GetWorkflowVersionAliasesResponses,
-  GetWorkflowVersionByIdData,
-  GetWorkflowVersionByIdErrors,
-  GetWorkflowVersionByIdResponses,
+  GetWorkflowVersionData,
+  GetWorkflowVersionErrors,
+  GetWorkflowVersionResponses,
   GetWorkflowVersionsData,
   GetWorkflowVersionsErrors,
   GetWorkflowVersionsResponses,
@@ -1813,6 +1813,9 @@ export const updateProject = <ThrowOnError extends boolean = false>(
  * Pagination is offset-based: ``skip`` is the number of records to skip
  * and ``limit`` caps the page size. Pass ``?include=files`` to eagerly
  * load file metadata for each sample.
+ *
+ * By default only the latest version of each file (by URI) is returned.
+ * Pass ``?file_versions=all`` to include all versions.
  */
 export const getProjectSamples = <ThrowOnError extends boolean = false>(
   options: Options<GetProjectSamplesData, ThrowOnError>,
@@ -2919,19 +2922,19 @@ export const createWorkflowVersion = <ThrowOnError extends boolean = false>(
 }
 
 /**
- * Get Workflow Version By Id
+ * Get Workflow Version
  * Get a specific workflow version.
  */
-export const getWorkflowVersionById = <ThrowOnError extends boolean = false>(
-  options: Options<GetWorkflowVersionByIdData, ThrowOnError>,
+export const getWorkflowVersion = <ThrowOnError extends boolean = false>(
+  options: Options<GetWorkflowVersionData, ThrowOnError>,
 ) => {
   return (options.client ?? _heyApiClient).get<
-    GetWorkflowVersionByIdResponses,
-    GetWorkflowVersionByIdErrors,
+    GetWorkflowVersionResponses,
+    GetWorkflowVersionErrors,
     ThrowOnError
   >({
     responseType: 'json',
-    url: '/api/v1/workflows/{workflow_id}/versions/{version_id}',
+    url: '/api/v1/workflows/{workflow_id}/versions/{version_num}',
     ...options,
   })
 }
@@ -3042,7 +3045,7 @@ export const getWorkflowDeployments = <ThrowOnError extends boolean = false>(
     ThrowOnError
   >({
     responseType: 'json',
-    url: '/api/v1/workflows/{workflow_id}/versions/{version_id}/deployments',
+    url: '/api/v1/workflows/{workflow_id}/versions/{version_num}/deployments',
     ...options,
   })
 }
@@ -3066,7 +3069,7 @@ export const createWorkflowDeployment = <ThrowOnError extends boolean = false>(
         type: 'http',
       },
     ],
-    url: '/api/v1/workflows/{workflow_id}/versions/{version_id}/deployments',
+    url: '/api/v1/workflows/{workflow_id}/versions/{version_num}/deployments',
     ...options,
     headers: {
       'Content-Type': 'application/json',
@@ -3087,7 +3090,7 @@ export const deleteWorkflowDeployment = <ThrowOnError extends boolean = false>(
     DeleteWorkflowDeploymentErrors,
     ThrowOnError
   >({
-    url: '/api/v1/workflows/{workflow_id}/versions/{version_id}/deployments/{deployment_id}',
+    url: '/api/v1/workflows/{workflow_id}/versions/{version_num}/deployments/{deployment_id}',
     ...options,
   })
 }

--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -215,6 +215,7 @@ export type ActionSubmitRequest = {
 
 /**
  * Attribute
+ * Reusable key-value pair for request/response payloads.
  */
 export type Attribute = {
   /**
@@ -1510,7 +1511,7 @@ export type PipelineCreate = {
   /**
    * Attributes
    */
-  attributes?: Array<ApiWorkflowModelsAttribute> | null
+  attributes?: Array<Attribute> | null
   /**
    * Workflow Ids
    */
@@ -1544,7 +1545,7 @@ export type PipelinePublic = {
   /**
    * Attributes
    */
-  attributes?: Array<ApiWorkflowModelsAttribute> | null
+  attributes?: Array<Attribute> | null
   /**
    * Workflows
    */
@@ -1646,7 +1647,7 @@ export type ProjectCreate = {
   /**
    * Attributes
    */
-  attributes?: Array<Attribute> | null
+  attributes?: Array<ApiProjectModelsAttribute> | null
 }
 
 /**
@@ -1672,7 +1673,7 @@ export type ProjectPublic = {
   /**
    * Attributes
    */
-  attributes: Array<Attribute> | null
+  attributes: Array<ApiProjectModelsAttribute> | null
   /**
    * Sequencing Runs
    */
@@ -1691,7 +1692,7 @@ export type ProjectUpdate = {
   /**
    * Attributes
    */
-  attributes?: Array<Attribute> | null
+  attributes?: Array<ApiProjectModelsAttribute> | null
 }
 
 /**
@@ -2094,6 +2095,10 @@ export type SampleFilePublic = {
   tags?: {
     [key: string]: string
   } | null
+  /**
+   * Created On
+   */
+  created_on: string
 }
 
 /**
@@ -2767,7 +2772,7 @@ export type WorkflowCreate = {
   /**
    * Attributes
    */
-  attributes?: Array<ApiWorkflowModelsAttribute> | null
+  attributes?: Array<Attribute> | null
 }
 
 /**
@@ -2837,7 +2842,7 @@ export type WorkflowPublic = {
   /**
    * Attributes
    */
-  attributes?: Array<ApiWorkflowModelsAttribute> | null
+  attributes?: Array<Attribute> | null
   /**
    * Versions
    */
@@ -2903,9 +2908,9 @@ export type WorkflowVersionAliasPublic = {
  */
 export type WorkflowVersionAliasSet = {
   /**
-   * Workflow Version Id
+   * Version Num
    */
-  workflow_version_id: string
+  version_num: number
 }
 
 /**
@@ -2919,7 +2924,7 @@ export type WorkflowVersionCreate = {
   /**
    * Attributes
    */
-  attributes?: Array<ApiWorkflowModelsAttribute> | null
+  attributes?: Array<Attribute> | null
 }
 
 /**
@@ -2957,7 +2962,7 @@ export type WorkflowVersionPublic = {
   /**
    * Attributes
    */
-  attributes?: Array<ApiWorkflowModelsAttribute> | null
+  attributes?: Array<Attribute> | null
 }
 
 /**
@@ -2981,12 +2986,16 @@ export type WorkflowVersionSummary = {
    * Created At
    */
   created_at: string
+  /**
+   * Deployments
+   */
+  deployments?: Array<WorkflowDeploymentPublic> | null
 }
 
 /**
  * Attribute
  */
-export type ApiSamplesModelsAttribute = {
+export type ApiProjectModelsAttribute = {
   /**
    * Key
    */
@@ -2999,9 +3008,8 @@ export type ApiSamplesModelsAttribute = {
 
 /**
  * Attribute
- * Reusable key-value pair for request/response payloads.
  */
-export type ApiWorkflowModelsAttribute = {
+export type ApiSamplesModelsAttribute = {
   /**
    * Key
    */
@@ -4497,11 +4505,8 @@ export type ReindexProjectsResponses = {
   /**
    * Successful Response
    */
-  201: ProjectsPublic
+  200: unknown
 }
-
-export type ReindexProjectsResponse =
-  ReindexProjectsResponses[keyof ReindexProjectsResponses]
 
 export type GetProjectByProjectIdData = {
   body?: never
@@ -4631,6 +4636,11 @@ export type GetProjectSamplesData = {
      * Include related data: files
      */
     include?: Array<string> | null
+    /**
+     * File Versions
+     * When include=files, controls file version behaviour. 'latest' (default) returns only the newest version per URI; 'all' returns every version.
+     */
+    file_versions?: 'latest' | 'all'
   }
   url: '/api/v1/projects/{project_id}/samples'
 }
@@ -5210,7 +5220,7 @@ export type ReindexRunsResponses = {
   /**
    * Successful Response
    */
-  201: unknown
+  200: unknown
 }
 
 export type ListDemultiplexWorkflowsData = {
@@ -6073,7 +6083,7 @@ export type CreateWorkflowVersionResponses = {
 export type CreateWorkflowVersionResponse =
   CreateWorkflowVersionResponses[keyof CreateWorkflowVersionResponses]
 
-export type GetWorkflowVersionByIdData = {
+export type GetWorkflowVersionData = {
   body?: never
   path: {
     /**
@@ -6081,33 +6091,33 @@ export type GetWorkflowVersionByIdData = {
      */
     workflow_id: string
     /**
-     * Version Id
+     * Version Num
      */
-    version_id: string
+    version_num: number
   }
   query?: never
-  url: '/api/v1/workflows/{workflow_id}/versions/{version_id}'
+  url: '/api/v1/workflows/{workflow_id}/versions/{version_num}'
 }
 
-export type GetWorkflowVersionByIdErrors = {
+export type GetWorkflowVersionErrors = {
   /**
    * Validation Error
    */
   422: HttpValidationError
 }
 
-export type GetWorkflowVersionByIdError =
-  GetWorkflowVersionByIdErrors[keyof GetWorkflowVersionByIdErrors]
+export type GetWorkflowVersionError =
+  GetWorkflowVersionErrors[keyof GetWorkflowVersionErrors]
 
-export type GetWorkflowVersionByIdResponses = {
+export type GetWorkflowVersionResponses = {
   /**
    * Successful Response
    */
   200: WorkflowVersionPublic
 }
 
-export type GetWorkflowVersionByIdResponse =
-  GetWorkflowVersionByIdResponses[keyof GetWorkflowVersionByIdResponses]
+export type GetWorkflowVersionResponse =
+  GetWorkflowVersionResponses[keyof GetWorkflowVersionResponses]
 
 export type DeleteWorkflowVersionAliasData = {
   body?: never
@@ -6272,9 +6282,9 @@ export type GetWorkflowDeploymentsData = {
      */
     workflow_id: string
     /**
-     * Version Id
+     * Version Num
      */
-    version_id: string
+    version_num: number
   }
   query?: {
     /**
@@ -6283,7 +6293,7 @@ export type GetWorkflowDeploymentsData = {
      */
     engine?: string | null
   }
-  url: '/api/v1/workflows/{workflow_id}/versions/{version_id}/deployments'
+  url: '/api/v1/workflows/{workflow_id}/versions/{version_num}/deployments'
 }
 
 export type GetWorkflowDeploymentsErrors = {
@@ -6315,12 +6325,12 @@ export type CreateWorkflowDeploymentData = {
      */
     workflow_id: string
     /**
-     * Version Id
+     * Version Num
      */
-    version_id: string
+    version_num: number
   }
   query?: never
-  url: '/api/v1/workflows/{workflow_id}/versions/{version_id}/deployments'
+  url: '/api/v1/workflows/{workflow_id}/versions/{version_num}/deployments'
 }
 
 export type CreateWorkflowDeploymentErrors = {
@@ -6351,16 +6361,16 @@ export type DeleteWorkflowDeploymentData = {
      */
     workflow_id: string
     /**
-     * Version Id
+     * Version Num
      */
-    version_id: string
+    version_num: number
     /**
      * Deployment Id
      */
     deployment_id: string
   }
   query?: never
-  url: '/api/v1/workflows/{workflow_id}/versions/{version_id}/deployments/{deployment_id}'
+  url: '/api/v1/workflows/{workflow_id}/versions/{version_num}/deployments/{deployment_id}'
 }
 
 export type DeleteWorkflowDeploymentErrors = {

--- a/src/routes/_auth.projects.$project_id.index.tsx
+++ b/src/routes/_auth.projects.$project_id.index.tsx
@@ -121,12 +121,12 @@ function RouteComponent() {
     const attributeColumns = Array.from(new Set(
       samples.flatMap(s => s.attributes?.map(a => a.key) || [])
     )).filter((name): name is string => name !== null && !RESERVED_SAMPLE_COLUMN_IDS.has(name))
-    const headers = ['sample_id', 'project_id', ...attributeColumns]
+    const headers = ['sample_id', ...attributeColumns]
     // TSV has no quoting; collapse tabs/newlines in cell values to single spaces.
     const sanitize = (v: unknown) => String(v ?? '').replace(/[\t\r\n]+/g, ' ')
     const rows = samples.map((s) => {
       const attrMap = new Map(s.attributes?.map((a) => [a.key, a.value]) || [])
-      return [s.sample_id, s.project_id, ...attributeColumns.map((c) => attrMap.get(c) ?? '')]
+      return [s.sample_id, ...attributeColumns.map((c) => attrMap.get(c) ?? '')]
         .map(sanitize)
         .join('\t')
     })


### PR DESCRIPTION
## Summary
- Regenerate client SDK to sync with latest API changes (version_num refactor, attribute type renames, file_versions param)
- Remove project_id column from TSV download to match the sample metadata table display

Fixes #75

## Test plan
- [ ] Download sample metadata TSV and verify project_id column is no longer present
- [ ] Verify no TypeScript errors from SDK regeneration