### PR TITLE
Add project metadata display and form fields

### DIFF
--- a/src/client/@tanstack/react-query.gen.ts
+++ b/src/client/@tanstack/react-query.gen.ts
@@ -103,6 +103,9 @@ import {
   searchQcrecordsGet,
   searchQcrecordsPost,
   searchRuns,
+  searchSamplesGet,
+  searchSamplesPost,
+  searchUsers,
   setWorkflowVersionAlias,
   submitDemultiplexWorkflowJob,
   submitJob,
@@ -316,6 +319,13 @@ import type {
   SearchRunsData,
   SearchRunsError,
   SearchRunsResponse,
+  SearchSamplesGetData,
+  SearchSamplesGetError,
+  SearchSamplesGetResponse,
+  SearchSamplesPostData,
+  SearchSamplesPostError,
+  SearchSamplesPostResponse,
+  SearchUsersData,
   SetWorkflowVersionAliasData,
   SetWorkflowVersionAliasError,
   SetWorkflowVersionAliasResponse,
@@ -4668,6 +4678,276 @@ export const removeSampleFromRunMutation = (
   return mutationOptions
 }
 
+export const searchSamplesGetQueryKey = (
+  options?: Options<SearchSamplesGetData>,
+) => createQueryKey('searchSamplesGet', options)
+
+/**
+ * Search Samples Get
+ * Search samples using query string parameters.
+ *
+ * Accepts key/value pairs as query params, e.g.:
+ * ``?projectid=P-1234&samplename=Sample_1&page=1&per_page=20``
+ *
+ * Supported filter keys:
+ * - ``projectid``: exact match on project ID
+ * - ``samplename``: exact match on sample name
+ * - ``created_on``: date prefix match (YYYY-MM-DD) on created_at
+ * - Any other key: matched against sample attributes (case-insensitive key)
+ *
+ * Multiple filters are AND'd together.
+ */
+export const searchSamplesGetOptions = (
+  options?: Options<SearchSamplesGetData>,
+) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await searchSamplesGet({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      })
+      return data
+    },
+    queryKey: searchSamplesGetQueryKey(options),
+  })
+}
+
+export const searchSamplesGetInfiniteQueryKey = (
+  options?: Options<SearchSamplesGetData>,
+): QueryKey<Options<SearchSamplesGetData>> =>
+  createQueryKey('searchSamplesGet', options, true)
+
+/**
+ * Search Samples Get
+ * Search samples using query string parameters.
+ *
+ * Accepts key/value pairs as query params, e.g.:
+ * ``?projectid=P-1234&samplename=Sample_1&page=1&per_page=20``
+ *
+ * Supported filter keys:
+ * - ``projectid``: exact match on project ID
+ * - ``samplename``: exact match on sample name
+ * - ``created_on``: date prefix match (YYYY-MM-DD) on created_at
+ * - Any other key: matched against sample attributes (case-insensitive key)
+ *
+ * Multiple filters are AND'd together.
+ */
+export const searchSamplesGetInfiniteOptions = (
+  options?: Options<SearchSamplesGetData>,
+) => {
+  return infiniteQueryOptions<
+    SearchSamplesGetResponse,
+    AxiosError<SearchSamplesGetError>,
+    InfiniteData<SearchSamplesGetResponse>,
+    QueryKey<Options<SearchSamplesGetData>>,
+    | number
+    | Pick<
+        QueryKey<Options<SearchSamplesGetData>>[0],
+        'body' | 'headers' | 'path' | 'query'
+      >
+  >(
+    // @ts-ignore
+    {
+      queryFn: async ({ pageParam, queryKey, signal }) => {
+        // @ts-ignore
+        const page: Pick<
+          QueryKey<Options<SearchSamplesGetData>>[0],
+          'body' | 'headers' | 'path' | 'query'
+        > =
+          typeof pageParam === 'object'
+            ? pageParam
+            : {
+                query: {
+                  page: pageParam,
+                },
+              }
+        const params = createInfiniteParams(queryKey, page)
+        const { data } = await searchSamplesGet({
+          ...options,
+          ...params,
+          signal,
+          throwOnError: true,
+        })
+        return data
+      },
+      queryKey: searchSamplesGetInfiniteQueryKey(options),
+    },
+  )
+}
+
+export const searchSamplesPostQueryKey = (
+  options: Options<SearchSamplesPostData>,
+) => createQueryKey('searchSamplesPost', options)
+
+/**
+ * Search Samples Post
+ * Search samples using JSON body with filter_on, page, per_page.
+ *
+ * Example body::
+ *
+ * {
+ * "filter_on": {
+ * "projectid": "P-1234",
+ * "tags": {
+ * "USUBJID": "CA123012-01-234"
+ * }
+ * },
+ * "page": 1,
+ * "per_page": 20
+ * }
+ *
+ * ``filter_on`` supports:
+ * - ``projectid`` (str or list)
+ * - ``samplename`` (str or list)
+ * - ``created_on`` (str, date prefix match)
+ * - ``tags`` (dict of key/value pairs, matched case-insensitively)
+ * - Any other key is matched against sample attributes
+ *
+ * List values are OR'd; multiple keys are AND'd.
+ */
+export const searchSamplesPostOptions = (
+  options: Options<SearchSamplesPostData>,
+) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await searchSamplesPost({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      })
+      return data
+    },
+    queryKey: searchSamplesPostQueryKey(options),
+  })
+}
+
+export const searchSamplesPostInfiniteQueryKey = (
+  options: Options<SearchSamplesPostData>,
+): QueryKey<Options<SearchSamplesPostData>> =>
+  createQueryKey('searchSamplesPost', options, true)
+
+/**
+ * Search Samples Post
+ * Search samples using JSON body with filter_on, page, per_page.
+ *
+ * Example body::
+ *
+ * {
+ * "filter_on": {
+ * "projectid": "P-1234",
+ * "tags": {
+ * "USUBJID": "CA123012-01-234"
+ * }
+ * },
+ * "page": 1,
+ * "per_page": 20
+ * }
+ *
+ * ``filter_on`` supports:
+ * - ``projectid`` (str or list)
+ * - ``samplename`` (str or list)
+ * - ``created_on`` (str, date prefix match)
+ * - ``tags`` (dict of key/value pairs, matched case-insensitively)
+ * - Any other key is matched against sample attributes
+ *
+ * List values are OR'd; multiple keys are AND'd.
+ */
+export const searchSamplesPostInfiniteOptions = (
+  options: Options<SearchSamplesPostData>,
+) => {
+  return infiniteQueryOptions<
+    SearchSamplesPostResponse,
+    AxiosError<SearchSamplesPostError>,
+    InfiniteData<SearchSamplesPostResponse>,
+    QueryKey<Options<SearchSamplesPostData>>,
+    | number
+    | Pick<
+        QueryKey<Options<SearchSamplesPostData>>[0],
+        'body' | 'headers' | 'path' | 'query'
+      >
+  >(
+    // @ts-ignore
+    {
+      queryFn: async ({ pageParam, queryKey, signal }) => {
+        // @ts-ignore
+        const page: Pick<
+          QueryKey<Options<SearchSamplesPostData>>[0],
+          'body' | 'headers' | 'path' | 'query'
+        > =
+          typeof pageParam === 'object'
+            ? pageParam
+            : {
+                body: {
+                  page: pageParam,
+                },
+              }
+        const params = createInfiniteParams(queryKey, page)
+        const { data } = await searchSamplesPost({
+          ...options,
+          ...params,
+          signal,
+          throwOnError: true,
+        })
+        return data
+      },
+      queryKey: searchSamplesPostInfiniteQueryKey(options),
+    },
+  )
+}
+
+/**
+ * Search Samples Post
+ * Search samples using JSON body with filter_on, page, per_page.
+ *
+ * Example body::
+ *
+ * {
+ * "filter_on": {
+ * "projectid": "P-1234",
+ * "tags": {
+ * "USUBJID": "CA123012-01-234"
+ * }
+ * },
+ * "page": 1,
+ * "per_page": 20
+ * }
+ *
+ * ``filter_on`` supports:
+ * - ``projectid`` (str or list)
+ * - ``samplename`` (str or list)
+ * - ``created_on`` (str, date prefix match)
+ * - ``tags`` (dict of key/value pairs, matched case-insensitively)
+ * - Any other key is matched against sample attributes
+ *
+ * List values are OR'd; multiple keys are AND'd.
+ */
+export const searchSamplesPostMutation = (
+  options?: Partial<Options<SearchSamplesPostData>>,
+): UseMutationOptions<
+  SearchSamplesPostResponse,
+  AxiosError<SearchSamplesPostError>,
+  Options<SearchSamplesPostData>
+> => {
+  const mutationOptions: UseMutationOptions<
+    SearchSamplesPostResponse,
+    AxiosError<SearchSamplesPostError>,
+    Options<SearchSamplesPostData>
+  > = {
+    mutationFn: async (localOptions) => {
+      const { data } = await searchSamplesPost({
+        ...options,
+        ...localOptions,
+        throwOnError: true,
+      })
+      return data
+    },
+  }
+  return mutationOptions
+}
+
 export const reindexSamplesQueryKey = (options?: Options<ReindexSamplesData>) =>
   createQueryKey('reindexSamples', options)
 
@@ -5765,5 +6045,32 @@ export const getPlatformByNameOptions = (
       return data
     },
     queryKey: getPlatformByNameQueryKey(options),
+  })
+}
+
+export const searchUsersQueryKey = (options: Options<SearchUsersData>) =>
+  createQueryKey('searchUsers', options)
+
+/**
+ * Search Users
+ * Search for users by name, email, or username.
+ *
+ * Uses LDAP directory if configured and available,
+ * otherwise falls back to the local user database.
+ *
+ * Requires authentication.
+ */
+export const searchUsersOptions = (options: Options<SearchUsersData>) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await searchUsers({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      })
+      return data
+    },
+    queryKey: searchUsersQueryKey(options),
   })
 }

--- a/src/client/@tanstack/react-query.gen.ts
+++ b/src/client/@tanstack/react-query.gen.ts
@@ -54,6 +54,7 @@ import {
   getPipelines,
   getPlatformByName,
   getPlatforms,
+  getProjectAttributes,
   getProjectByProjectId,
   getProjectSamples,
   getProjects,
@@ -70,8 +71,8 @@ import {
   getWorkflowById,
   getWorkflowDeployments,
   getWorkflowDeploymentsForWorkflow,
+  getWorkflowVersion,
   getWorkflowVersionAliases,
-  getWorkflowVersionById,
   getWorkflowVersions,
   getWorkflows,
   healthCheck,
@@ -222,6 +223,7 @@ import type {
   GetPipelinesResponse,
   GetPlatformByNameData,
   GetPlatformsData,
+  GetProjectAttributesData,
   GetProjectByProjectIdData,
   GetProjectSamplesData,
   GetProjectsData,
@@ -243,7 +245,7 @@ import type {
   GetWorkflowDeploymentsData,
   GetWorkflowDeploymentsForWorkflowData,
   GetWorkflowVersionAliasesData,
-  GetWorkflowVersionByIdData,
+  GetWorkflowVersionData,
   GetWorkflowVersionsData,
   GetWorkflowsData,
   GetWorkflowsError,
@@ -283,7 +285,6 @@ import type {
   RegisterError,
   RegisterResponse,
   ReindexProjectsData,
-  ReindexProjectsResponse,
   ReindexRunsData,
   ReindexSamplesData,
   RemoveSampleFromRunData,
@@ -2814,6 +2815,35 @@ export const createProjectMutation = (
   return mutationOptions
 }
 
+export const getProjectAttributesQueryKey = (
+  options?: Options<GetProjectAttributesData>,
+) => createQueryKey('getProjectAttributes', options)
+
+/**
+ * Get Project Attributes
+ * Returns a list of all unique project attributes across all projects.
+ *
+ * This endpoint is useful for clients to discover what attributes are in use
+ * and to populate dropdowns or autocomplete fields when creating/updating
+ * projects.  The response is a flat list of unique attribute keys.
+ */
+export const getProjectAttributesOptions = (
+  options?: Options<GetProjectAttributesData>,
+) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await getProjectAttributes({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      })
+      return data
+    },
+    queryKey: getProjectAttributesQueryKey(options),
+  })
+}
+
 export const searchProjectsQueryKey = (options: Options<SearchProjectsData>) =>
   createQueryKey('searchProjects', options)
 
@@ -2920,12 +2950,12 @@ export const reindexProjectsOptions = (
 export const reindexProjectsMutation = (
   options?: Partial<Options<ReindexProjectsData>>,
 ): UseMutationOptions<
-  ReindexProjectsResponse,
+  unknown,
   AxiosError<DefaultError>,
   Options<ReindexProjectsData>
 > => {
   const mutationOptions: UseMutationOptions<
-    ReindexProjectsResponse,
+    unknown,
     AxiosError<DefaultError>,
     Options<ReindexProjectsData>
   > = {
@@ -3043,6 +3073,9 @@ export const getProjectSamplesQueryKey = (
  * Pagination is offset-based: ``skip`` is the number of records to skip
  * and ``limit`` caps the page size. Pass ``?include=files`` to eagerly
  * load file metadata for each sample.
+ *
+ * By default only the latest version of each file (by URI) is returned.
+ * Pass ``?file_versions=all`` to include all versions.
  */
 export const getProjectSamplesOptions = (
   options: Options<GetProjectSamplesData>,
@@ -5163,20 +5196,20 @@ export const createWorkflowVersionMutation = (
   return mutationOptions
 }
 
-export const getWorkflowVersionByIdQueryKey = (
-  options: Options<GetWorkflowVersionByIdData>,
-) => createQueryKey('getWorkflowVersionById', options)
+export const getWorkflowVersionQueryKey = (
+  options: Options<GetWorkflowVersionData>,
+) => createQueryKey('getWorkflowVersion', options)
 
 /**
- * Get Workflow Version By Id
+ * Get Workflow Version
  * Get a specific workflow version.
  */
-export const getWorkflowVersionByIdOptions = (
-  options: Options<GetWorkflowVersionByIdData>,
+export const getWorkflowVersionOptions = (
+  options: Options<GetWorkflowVersionData>,
 ) => {
   return queryOptions({
     queryFn: async ({ queryKey, signal }) => {
-      const { data } = await getWorkflowVersionById({
+      const { data } = await getWorkflowVersion({
         ...options,
         ...queryKey[0],
         signal,
@@ -5184,7 +5217,7 @@ export const getWorkflowVersionByIdOptions = (
       })
       return data
     },
-    queryKey: getWorkflowVersionByIdQueryKey(options),
+    queryKey: getWorkflowVersionQueryKey(options),
   })
 }
 

--- a/src/client/sdk.gen.ts
+++ b/src/client/sdk.gen.ts
@@ -279,6 +279,15 @@ import type {
   SearchRunsData,
   SearchRunsErrors,
   SearchRunsResponses,
+  SearchSamplesGetData,
+  SearchSamplesGetErrors,
+  SearchSamplesGetResponses,
+  SearchSamplesPostData,
+  SearchSamplesPostErrors,
+  SearchSamplesPostResponses,
+  SearchUsersData,
+  SearchUsersErrors,
+  SearchUsersResponses,
   SetWorkflowVersionAliasData,
   SetWorkflowVersionAliasErrors,
   SetWorkflowVersionAliasResponses,
@@ -2649,6 +2658,79 @@ export const removeSampleFromRun = <ThrowOnError extends boolean = false>(
 }
 
 /**
+ * Search Samples Get
+ * Search samples using query string parameters.
+ *
+ * Accepts key/value pairs as query params, e.g.:
+ * ``?projectid=P-1234&samplename=Sample_1&page=1&per_page=20``
+ *
+ * Supported filter keys:
+ * - ``projectid``: exact match on project ID
+ * - ``samplename``: exact match on sample name
+ * - ``created_on``: date prefix match (YYYY-MM-DD) on created_at
+ * - Any other key: matched against sample attributes (case-insensitive key)
+ *
+ * Multiple filters are AND'd together.
+ */
+export const searchSamplesGet = <ThrowOnError extends boolean = false>(
+  options?: Options<SearchSamplesGetData, ThrowOnError>,
+) => {
+  return (options?.client ?? _heyApiClient).get<
+    SearchSamplesGetResponses,
+    SearchSamplesGetErrors,
+    ThrowOnError
+  >({
+    responseType: 'json',
+    url: '/api/v1/samples/search',
+    ...options,
+  })
+}
+
+/**
+ * Search Samples Post
+ * Search samples using JSON body with filter_on, page, per_page.
+ *
+ * Example body::
+ *
+ * {
+ * "filter_on": {
+ * "projectid": "P-1234",
+ * "tags": {
+ * "USUBJID": "CA123012-01-234"
+ * }
+ * },
+ * "page": 1,
+ * "per_page": 20
+ * }
+ *
+ * ``filter_on`` supports:
+ * - ``projectid`` (str or list)
+ * - ``samplename`` (str or list)
+ * - ``created_on`` (str, date prefix match)
+ * - ``tags`` (dict of key/value pairs, matched case-insensitively)
+ * - Any other key is matched against sample attributes
+ *
+ * List values are OR'd; multiple keys are AND'd.
+ */
+export const searchSamplesPost = <ThrowOnError extends boolean = false>(
+  options: Options<SearchSamplesPostData, ThrowOnError>,
+) => {
+  return (options.client ?? _heyApiClient).post<
+    SearchSamplesPostResponses,
+    SearchSamplesPostErrors,
+    ThrowOnError
+  >({
+    responseType: 'json',
+    url: '/api/v1/samples/search',
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  })
+}
+
+/**
  * Reindex Samples
  * Reindex samples in database with OpenSearch
  */
@@ -2661,7 +2743,7 @@ export const reindexSamples = <ThrowOnError extends boolean = false>(
     ThrowOnError
   >({
     responseType: 'json',
-    url: '/api/v1/samples/search',
+    url: '/api/v1/samples/reindex',
     ...options,
   })
 }
@@ -3286,6 +3368,35 @@ export const getPlatformByName = <ThrowOnError extends boolean = false>(
   >({
     responseType: 'json',
     url: '/api/v1/platforms/{name}',
+    ...options,
+  })
+}
+
+/**
+ * Search Users
+ * Search for users by name, email, or username.
+ *
+ * Uses LDAP directory if configured and available,
+ * otherwise falls back to the local user database.
+ *
+ * Requires authentication.
+ */
+export const searchUsers = <ThrowOnError extends boolean = false>(
+  options: Options<SearchUsersData, ThrowOnError>,
+) => {
+  return (options.client ?? _heyApiClient).get<
+    SearchUsersResponses,
+    SearchUsersErrors,
+    ThrowOnError
+  >({
+    responseType: 'json',
+    security: [
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+    ],
+    url: '/api/v1/users/search',
     ...options,
   })
 }

--- a/src/client/sdk.gen.ts
+++ b/src/client/sdk.gen.ts
@@ -139,6 +139,8 @@ import type {
   GetPlatformByNameResponses,
   GetPlatformsData,
   GetPlatformsResponses,
+  GetProjectAttributesData,
+  GetProjectAttributesResponses,
   GetProjectByProjectIdData,
   GetProjectByProjectIdErrors,
   GetProjectByProjectIdResponses,
@@ -190,9 +192,9 @@ import type {
   GetWorkflowVersionAliasesData,
   GetWorkflowVersionAliasesErrors,
   GetWorkflowVersionAliasesResponses,
-  GetWorkflowVersionByIdData,
-  GetWorkflowVersionByIdErrors,
-  GetWorkflowVersionByIdResponses,
+  GetWorkflowVersionData,
+  GetWorkflowVersionErrors,
+  GetWorkflowVersionResponses,
   GetWorkflowVersionsData,
   GetWorkflowVersionsErrors,
   GetWorkflowVersionsResponses,
@@ -1689,12 +1691,40 @@ export const createProject = <ThrowOnError extends boolean = false>(
     ThrowOnError
   >({
     responseType: 'json',
+    security: [
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+    ],
     url: '/api/v1/projects',
     ...options,
     headers: {
       'Content-Type': 'application/json',
       ...options.headers,
     },
+  })
+}
+
+/**
+ * Get Project Attributes
+ * Returns a list of all unique project attributes across all projects.
+ *
+ * This endpoint is useful for clients to discover what attributes are in use
+ * and to populate dropdowns or autocomplete fields when creating/updating
+ * projects.  The response is a flat list of unique attribute keys.
+ */
+export const getProjectAttributes = <ThrowOnError extends boolean = false>(
+  options?: Options<GetProjectAttributesData, ThrowOnError>,
+) => {
+  return (options?.client ?? _heyApiClient).get<
+    GetProjectAttributesResponses,
+    unknown,
+    ThrowOnError
+  >({
+    responseType: 'json',
+    url: '/api/v1/projects/attributes',
+    ...options,
   })
 }
 
@@ -1813,6 +1843,9 @@ export const updateProject = <ThrowOnError extends boolean = false>(
  * Pagination is offset-based: ``skip`` is the number of records to skip
  * and ``limit`` caps the page size. Pass ``?include=files`` to eagerly
  * load file metadata for each sample.
+ *
+ * By default only the latest version of each file (by URI) is returned.
+ * Pass ``?file_versions=all`` to include all versions.
  */
 export const getProjectSamples = <ThrowOnError extends boolean = false>(
   options: Options<GetProjectSamplesData, ThrowOnError>,
@@ -2919,19 +2952,19 @@ export const createWorkflowVersion = <ThrowOnError extends boolean = false>(
 }
 
 /**
- * Get Workflow Version By Id
+ * Get Workflow Version
  * Get a specific workflow version.
  */
-export const getWorkflowVersionById = <ThrowOnError extends boolean = false>(
-  options: Options<GetWorkflowVersionByIdData, ThrowOnError>,
+export const getWorkflowVersion = <ThrowOnError extends boolean = false>(
+  options: Options<GetWorkflowVersionData, ThrowOnError>,
 ) => {
   return (options.client ?? _heyApiClient).get<
-    GetWorkflowVersionByIdResponses,
-    GetWorkflowVersionByIdErrors,
+    GetWorkflowVersionResponses,
+    GetWorkflowVersionErrors,
     ThrowOnError
   >({
     responseType: 'json',
-    url: '/api/v1/workflows/{workflow_id}/versions/{version_id}',
+    url: '/api/v1/workflows/{workflow_id}/versions/{version_num}',
     ...options,
   })
 }
@@ -3042,7 +3075,7 @@ export const getWorkflowDeployments = <ThrowOnError extends boolean = false>(
     ThrowOnError
   >({
     responseType: 'json',
-    url: '/api/v1/workflows/{workflow_id}/versions/{version_id}/deployments',
+    url: '/api/v1/workflows/{workflow_id}/versions/{version_num}/deployments',
     ...options,
   })
 }
@@ -3066,7 +3099,7 @@ export const createWorkflowDeployment = <ThrowOnError extends boolean = false>(
         type: 'http',
       },
     ],
-    url: '/api/v1/workflows/{workflow_id}/versions/{version_id}/deployments',
+    url: '/api/v1/workflows/{workflow_id}/versions/{version_num}/deployments',
     ...options,
     headers: {
       'Content-Type': 'application/json',
@@ -3087,7 +3120,7 @@ export const deleteWorkflowDeployment = <ThrowOnError extends boolean = false>(
     DeleteWorkflowDeploymentErrors,
     ThrowOnError
   >({
-    url: '/api/v1/workflows/{workflow_id}/versions/{version_id}/deployments/{deployment_id}',
+    url: '/api/v1/workflows/{workflow_id}/versions/{version_num}/deployments/{deployment_id}',
     ...options,
   })
 }

--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -1662,6 +1662,18 @@ export type ProjectPublic = {
    */
   name: string | null
   /**
+   * Created By
+   */
+  created_by: string
+  /**
+   * Created At
+   */
+  created_at: string
+  /**
+   * Last Modified
+   */
+  last_modified: string
+  /**
    * Data Folder Uri
    */
   data_folder_uri: string | null
@@ -2094,6 +2106,10 @@ export type SampleFilePublic = {
   tags?: {
     [key: string]: string
   } | null
+  /**
+   * Created On
+   */
+  created_on: string
 }
 
 /**
@@ -2903,9 +2919,9 @@ export type WorkflowVersionAliasPublic = {
  */
 export type WorkflowVersionAliasSet = {
   /**
-   * Workflow Version Id
+   * Version Num
    */
-  workflow_version_id: string
+  version_num: number
 }
 
 /**
@@ -2981,6 +2997,10 @@ export type WorkflowVersionSummary = {
    * Created At
    */
   created_at: string
+  /**
+   * Deployments
+   */
+  deployments?: Array<WorkflowDeploymentPublic> | null
 }
 
 /**
@@ -4433,6 +4453,24 @@ export type CreateProjectResponses = {
 export type CreateProjectResponse =
   CreateProjectResponses[keyof CreateProjectResponses]
 
+export type GetProjectAttributesData = {
+  body?: never
+  path?: never
+  query?: never
+  url: '/api/v1/projects/attributes'
+}
+
+export type GetProjectAttributesResponses = {
+  /**
+   * Response Get Project Attributes
+   * Successful Response
+   */
+  200: Array<string>
+}
+
+export type GetProjectAttributesResponse =
+  GetProjectAttributesResponses[keyof GetProjectAttributesResponses]
+
 export type SearchProjectsData = {
   body?: never
   path?: never
@@ -4497,11 +4535,8 @@ export type ReindexProjectsResponses = {
   /**
    * Successful Response
    */
-  201: ProjectsPublic
+  200: unknown
 }
-
-export type ReindexProjectsResponse =
-  ReindexProjectsResponses[keyof ReindexProjectsResponses]
 
 export type GetProjectByProjectIdData = {
   body?: never
@@ -4631,6 +4666,11 @@ export type GetProjectSamplesData = {
      * Include related data: files
      */
     include?: Array<string> | null
+    /**
+     * File Versions
+     * When include=files, controls file version behaviour. 'latest' (default) returns only the newest version per URI; 'all' returns every version.
+     */
+    file_versions?: 'latest' | 'all'
   }
   url: '/api/v1/projects/{project_id}/samples'
 }
@@ -5210,7 +5250,7 @@ export type ReindexRunsResponses = {
   /**
    * Successful Response
    */
-  201: unknown
+  200: unknown
 }
 
 export type ListDemultiplexWorkflowsData = {
@@ -6073,7 +6113,7 @@ export type CreateWorkflowVersionResponses = {
 export type CreateWorkflowVersionResponse =
   CreateWorkflowVersionResponses[keyof CreateWorkflowVersionResponses]
 
-export type GetWorkflowVersionByIdData = {
+export type GetWorkflowVersionData = {
   body?: never
   path: {
     /**
@@ -6081,33 +6121,33 @@ export type GetWorkflowVersionByIdData = {
      */
     workflow_id: string
     /**
-     * Version Id
+     * Version Num
      */
-    version_id: string
+    version_num: number
   }
   query?: never
-  url: '/api/v1/workflows/{workflow_id}/versions/{version_id}'
+  url: '/api/v1/workflows/{workflow_id}/versions/{version_num}'
 }
 
-export type GetWorkflowVersionByIdErrors = {
+export type GetWorkflowVersionErrors = {
   /**
    * Validation Error
    */
   422: HttpValidationError
 }
 
-export type GetWorkflowVersionByIdError =
-  GetWorkflowVersionByIdErrors[keyof GetWorkflowVersionByIdErrors]
+export type GetWorkflowVersionError =
+  GetWorkflowVersionErrors[keyof GetWorkflowVersionErrors]
 
-export type GetWorkflowVersionByIdResponses = {
+export type GetWorkflowVersionResponses = {
   /**
    * Successful Response
    */
   200: WorkflowVersionPublic
 }
 
-export type GetWorkflowVersionByIdResponse =
-  GetWorkflowVersionByIdResponses[keyof GetWorkflowVersionByIdResponses]
+export type GetWorkflowVersionResponse =
+  GetWorkflowVersionResponses[keyof GetWorkflowVersionResponses]
 
 export type DeleteWorkflowVersionAliasData = {
   body?: never
@@ -6272,9 +6312,9 @@ export type GetWorkflowDeploymentsData = {
      */
     workflow_id: string
     /**
-     * Version Id
+     * Version Num
      */
-    version_id: string
+    version_num: number
   }
   query?: {
     /**
@@ -6283,7 +6323,7 @@ export type GetWorkflowDeploymentsData = {
      */
     engine?: string | null
   }
-  url: '/api/v1/workflows/{workflow_id}/versions/{version_id}/deployments'
+  url: '/api/v1/workflows/{workflow_id}/versions/{version_num}/deployments'
 }
 
 export type GetWorkflowDeploymentsErrors = {
@@ -6315,12 +6355,12 @@ export type CreateWorkflowDeploymentData = {
      */
     workflow_id: string
     /**
-     * Version Id
+     * Version Num
      */
-    version_id: string
+    version_num: number
   }
   query?: never
-  url: '/api/v1/workflows/{workflow_id}/versions/{version_id}/deployments'
+  url: '/api/v1/workflows/{workflow_id}/versions/{version_num}/deployments'
 }
 
 export type CreateWorkflowDeploymentErrors = {
@@ -6351,16 +6391,16 @@ export type DeleteWorkflowDeploymentData = {
      */
     workflow_id: string
     /**
-     * Version Id
+     * Version Num
      */
-    version_id: string
+    version_num: number
     /**
      * Deployment Id
      */
     deployment_id: string
   }
   query?: never
-  url: '/api/v1/workflows/{workflow_id}/versions/{version_id}/deployments/{deployment_id}'
+  url: '/api/v1/workflows/{workflow_id}/versions/{version_num}/deployments/{deployment_id}'
 }
 
 export type DeleteWorkflowDeploymentErrors = {

--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -2151,6 +2151,27 @@ export type SamplePublic = {
 }
 
 /**
+ * SampleSearchRequest
+ * POST /api/v1/samples/search request body.
+ */
+export type SampleSearchRequest = {
+  /**
+   * Filter On
+   */
+  filter_on?: {
+    [key: string]: unknown
+  }
+  /**
+   * Page
+   */
+  page?: number
+  /**
+   * Per Page
+   */
+  per_page?: number
+}
+
+/**
  * SampleSequencingRunCreate
  */
 export type SampleSequencingRunCreate = {
@@ -2215,6 +2236,7 @@ export type SampleWithFilesPublic = {
 
 /**
  * SamplesPublic
+ * Paginated list of samples using offset-based pagination (skip/limit).
  */
 export type SamplesPublic = {
   /**
@@ -2237,6 +2259,45 @@ export type SamplesPublic = {
    * Limit
    */
   limit: number
+  /**
+   * Has Next
+   */
+  has_next: boolean
+  /**
+   * Has Prev
+   */
+  has_prev: boolean
+}
+
+/**
+ * SamplesPublicSearchResponse
+ * Paginated list of samples using page-based pagination for search endpoints.
+ */
+export type SamplesPublicSearchResponse = {
+  /**
+   * Data
+   */
+  data: Array<SamplePublic>
+  /**
+   * Data Cols
+   */
+  data_cols?: Array<string> | null
+  /**
+   * Total Items
+   */
+  total_items: number
+  /**
+   * Total Pages
+   */
+  total_pages: number
+  /**
+   * Current Page
+   */
+  current_page: number
+  /**
+   * Per Page
+   */
+  per_page: number
   /**
    * Has Next
    */
@@ -2288,6 +2349,7 @@ export type SamplesWithFilesPublic = {
 export type SearchResponse = {
   projects: ProjectsPublic
   runs: SequencingRunsPublic
+  samples: SamplesPublicSearchResponse
 }
 
 /**
@@ -2628,6 +2690,60 @@ export type UserRegister = {
    * Full Name
    */
   full_name?: string | null
+}
+
+/**
+ * UserSearchResponse
+ * User search response
+ */
+export type UserSearchResponse = {
+  /**
+   * Data
+   */
+  data: Array<UserSearchResult>
+  /**
+   * Count
+   */
+  count: number
+  /**
+   * Query
+   */
+  query: string
+  /**
+   * Source
+   */
+  source: string
+}
+
+/**
+ * UserSearchResult
+ * Unified user search result from either LDAP or database
+ */
+export type UserSearchResult = {
+  /**
+   * Username
+   */
+  username: string
+  /**
+   * Email
+   */
+  email?: string | null
+  /**
+   * Full Name
+   */
+  full_name?: string | null
+  /**
+   * Department
+   */
+  department?: string | null
+  /**
+   * Title
+   */
+  title?: string | null
+  /**
+   * Source
+   */
+  source: string
 }
 
 /**
@@ -5628,11 +5744,76 @@ export type RemoveSampleFromRunResponses = {
 export type RemoveSampleFromRunResponse =
   RemoveSampleFromRunResponses[keyof RemoveSampleFromRunResponses]
 
+export type SearchSamplesGetData = {
+  body?: never
+  path?: never
+  query?: {
+    /**
+     * Page
+     * Page number (1-indexed)
+     */
+    page?: number
+    /**
+     * Per Page
+     * Number of items per page
+     */
+    per_page?: number
+  }
+  url: '/api/v1/samples/search'
+}
+
+export type SearchSamplesGetErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError
+}
+
+export type SearchSamplesGetError =
+  SearchSamplesGetErrors[keyof SearchSamplesGetErrors]
+
+export type SearchSamplesGetResponses = {
+  /**
+   * Successful Response
+   */
+  200: SamplesPublicSearchResponse
+}
+
+export type SearchSamplesGetResponse =
+  SearchSamplesGetResponses[keyof SearchSamplesGetResponses]
+
+export type SearchSamplesPostData = {
+  body: SampleSearchRequest
+  path?: never
+  query?: never
+  url: '/api/v1/samples/search'
+}
+
+export type SearchSamplesPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError
+}
+
+export type SearchSamplesPostError =
+  SearchSamplesPostErrors[keyof SearchSamplesPostErrors]
+
+export type SearchSamplesPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: SamplesPublicSearchResponse
+}
+
+export type SearchSamplesPostResponse =
+  SearchSamplesPostResponses[keyof SearchSamplesPostResponses]
+
 export type ReindexSamplesData = {
   body?: never
   path?: never
   query?: never
-  url: '/api/v1/samples/search'
+  url: '/api/v1/samples/reindex'
 }
 
 export type ReindexSamplesResponses = {
@@ -6682,6 +6863,43 @@ export type GetPlatformByNameResponses = {
 
 export type GetPlatformByNameResponse =
   GetPlatformByNameResponses[keyof GetPlatformByNameResponses]
+
+export type SearchUsersData = {
+  body?: never
+  path?: never
+  query: {
+    /**
+     * Q
+     * Search query (min 2 characters)
+     */
+    q: string
+    /**
+     * Limit
+     * Max results to return
+     */
+    limit?: number
+  }
+  url: '/api/v1/users/search'
+}
+
+export type SearchUsersErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError
+}
+
+export type SearchUsersError = SearchUsersErrors[keyof SearchUsersErrors]
+
+export type SearchUsersResponses = {
+  /**
+   * Successful Response
+   */
+  200: UserSearchResponse
+}
+
+export type SearchUsersResponse =
+  SearchUsersResponses[keyof SearchUsersResponses]
 
 export type ClientOptions = {
   baseURL: 'http://apiserver:3000' | (string & {})

--- a/src/components/breadcrumb-nav.tsx
+++ b/src/components/breadcrumb-nav.tsx
@@ -36,13 +36,16 @@ export const BreadcrumbNav: React.FC = () => {
           }
           return (
             <React.Fragment key={index}>
-              <BreadcrumbItem className="hidden md:block">
+              <BreadcrumbItem className="hidden md:block max-w-[50vw] lg:max-w-[60vw]">
                 {isLast || !item.includeCrumbLink ? (
-                  <BreadcrumbPage className={!item.includeCrumbLink ? "text-muted-foreground" : ""}>
+                  <BreadcrumbPage
+                    className={`line-clamp-1 ${!item.includeCrumbLink ? "text-muted-foreground" : ""}`}
+                    title={item.crumb}
+                  >
                     {item.crumb}
                   </BreadcrumbPage>
                 ) : (
-                  <Link to={item.href} preload={false}>
+                  <Link to={item.href} preload={false} className="line-clamp-1" title={item.crumb}>
                     {index < 1 ? <Home size={14} /> : item.crumb}
                   </Link>
                 )}

--- a/src/components/create-project-form.tsx
+++ b/src/components/create-project-form.tsx
@@ -9,6 +9,7 @@ import { useNavigate } from "@tanstack/react-router";
 import type { JSX } from "react";
 import type { SubmitHandler } from "react-hook-form";
 import type { ProjectPublic } from "@/client"
+import { useCurrentUser } from "@/hooks/use-current-user";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -57,6 +58,7 @@ export const CreateProjectForm: React.FC<CreateProjectFormProps> = ({ trigger, i
   const baseId = (idPrefix || `create-project-${generatedId.replace(/:/g, '')}`).replace(/[^a-zA-Z0-9_-]+/g, '-');
 
   const navigate = useNavigate();
+  const { data: currentUser } = useCurrentUser();
 
   // Control dialog open/close state
   const [isOpen, setIsOpen] = useState(false);
@@ -153,6 +155,15 @@ export const CreateProjectForm: React.FC<CreateProjectFormProps> = ({ trigger, i
                     {errors.name.message}
                   </div>
                 )}
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor={`${baseId}-created-by`}>Created by</Label>
+                <Input
+                  id={`${baseId}-created-by`}
+                  type="text"
+                  value={currentUser?.username ?? ''}
+                  disabled
+                />
               </div>
               <div className="grid gap-2 mb-6">
                 <Label>Attributes</Label>

--- a/src/components/update-project-form.tsx
+++ b/src/components/update-project-form.tsx
@@ -50,16 +50,19 @@ interface UpdateProjectFormProps {
   projectId: string
   /** The current project name */
   projectName: string | null
+  /** The user who created the project */
+  projectCreatedBy: string
   /** The current project attributes */
   projectAttributes?: Array<{ key: string | null; value: string | null }> | null
   /** Optional DOM id prefix for this form instance */
   idPrefix?: string
 }
 
-export const UpdateProjectForm: React.FC<UpdateProjectFormProps> = ({ 
-  trigger, 
-  projectId, 
-  projectName, 
+export const UpdateProjectForm: React.FC<UpdateProjectFormProps> = ({
+  trigger,
+  projectId,
+  projectName,
+  projectCreatedBy,
   projectAttributes,
   idPrefix,
 }) => {
@@ -176,6 +179,15 @@ export const UpdateProjectForm: React.FC<UpdateProjectFormProps> = ({
                     {errors.name.message}
                   </div>
                 )}
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor={`${baseId}-created-by`}>Created by</Label>
+                <Input
+                  id={`${baseId}-created-by`}
+                  type="text"
+                  value={projectCreatedBy}
+                  disabled
+                />
               </div>
               <div className="grid gap-2 mb-6">
                 <Label>Attributes</Label>

--- a/src/routes/_auth.projects.$project_id.index.tsx
+++ b/src/routes/_auth.projects.$project_id.index.tsx
@@ -335,6 +335,7 @@ function RouteComponent() {
                 idPrefix={`project-${project.project_id}-update-project`}
                 projectId={project.project_id}
                 projectName={project.name}
+                projectCreatedBy={project.created_by}
                 projectAttributes={project.attributes}
                 trigger={
                   <Button variant='outline' className='w-full md:w-fit'>

--- a/src/routes/_auth.projects.$project_id.route.tsx
+++ b/src/routes/_auth.projects.$project_id.route.tsx
@@ -1,4 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query'
+import { Calendar, Clock, User } from 'lucide-react'
 import { Outlet, createFileRoute } from '@tanstack/react-router'
 import { getProjectByProjectId } from '@/client'
 import { getProjectByProjectIdOptions } from '@/client/@tanstack/react-query.gen'
@@ -34,11 +35,34 @@ function RouteComponent() {
     })
   )
 
+  const isEpoch = (dateStr: string) => dateStr.startsWith('1970-01-01')
+  const hasCreator = project.created_by && project.created_by !== 'unknown'
+  const hasCreatedAt = !isEpoch(project.created_at)
+  const hasLastModified = !isEpoch(project.last_modified)
+
+  const createdAt = hasCreatedAt ? new Date(project.created_at).toLocaleDateString('en-US', {
+    month: 'short', day: 'numeric', year: 'numeric'
+  }) : null
+  const lastModified = hasLastModified ? new Date(project.last_modified).toLocaleDateString('en-US', {
+    month: 'short', day: 'numeric', year: 'numeric'
+  }) : null
+
+  const showMetadata = hasCreator || hasCreatedAt || hasLastModified
+
   return (
     <>
       <div className='flex flex-col gap-4'>
         {/* Header */}
-        <h1 className='text-3xl font-extralight'>{project.name}</h1>
+        <div>
+          <h1 className='text-3xl font-extralight'>{project.name}</h1>
+          {showMetadata && (
+            <div className='flex flex-col sm:flex-row sm:flex-wrap gap-1 sm:gap-3 mt-1 text-sm text-muted-foreground'>
+              {hasCreator && <span className='inline-flex items-center gap-1'><User size={14} />Created by <span className='font-semibold'>{project.created_by}</span></span>}
+              {hasCreatedAt && <span className='inline-flex items-center gap-1'><Calendar size={14} />Created on <span className='font-semibold'>{createdAt}</span></span>}
+              {hasLastModified && <span className='inline-flex items-center gap-1'><Clock size={14} />Modified <span className='font-semibold'>{lastModified}</span></span>}
+            </div>
+          )}
+        </div>
         {/* Outlet */}
         <Outlet />
       </div>


### PR DESCRIPTION
## Summary
- Truncate long project names in breadcrumb nav using line-clamp with responsive max-width
- Display created_by, created_at, and last_modified below project title with icons
- Hide metadata items when values are not meaningful (unknown creator or epoch dates)
- Show disabled "Created by" field in create (current user) and update (original creator) forms
- Regenerated client SDK to include new ProjectPublic fields

## Expected behavior
- Long project names are truncated in the breadcrumb with ellipsis; full name shows on hover
- Project detail page shows creator, creation date, and last modified date below the title
- Projects with unknown creator or epoch dates hide those specific metadata items gracefully
- Create project form shows the currently logged-in user as the creator (read-only)
- Update project form shows the original project creator (read-only)