### PR TITLE
Fix Safari header layout break when pasting into search

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -56,7 +56,7 @@ export default function Header() {
           className="pl-2 cursor-pointer"
           onClick={() => navigate({ to: '/' })}
         >
-          <NGS360Logo iconSize="max-w-[35px]" textSize="text-xl" gap="gap-2" className="p-2" />
+          <NGS360Logo iconSize="size-[35px]" textSize="text-xl" gap="gap-2" className="p-2" />
         </div>
 
         {/* Desktop Nav Items */}


### PR DESCRIPTION
## Problem
Pasting into the header search bar broke the header layout — the search box, Create Project button, notifications, and avatar were pushed off the right edge. **Safari-only and production-build-only.**

## Root cause
The NGS360 logo was rendered with `max-w-[35px]` — that sets only `max-width`, never a definite width, on the SVG `<img>`. The SVG declares its intrinsic size in millimeters (`218.52mm` ≈ 826px).

WebKit has a flexbox bug: it fails to clamp a flex item's automatic minimum size (`min-width: auto` → min-content) by `max-width`. So when a paste triggered a reflow (the search-results popover opening), Safari sized the logo's flex item to the SVG's full ~826px intrinsic width. That ballooned `header-left` to ~1373px and shoved the right-side controls off-screen. Chrome/Firefox apply the clamp correctly, so they were unaffected.

## Fix
Give the logo a **definite** width so there's no min-content to inflate:

```diff
- <NGS360Logo iconSize="max-w-[35px]" ... />
+ <NGS360Logo iconSize="size-[35px]" ... />
```

## Testing
Verified in Safari against a production build (`npm run build && npm run preview`): pasting into the search bar no longer disturbs the header. Confirmed via console that `header-left` returns to ~550px and the header no longer overflows the viewport.