### PR TITLE
Migrate generated API client from axios to fetch

### DIFF
--- a/openapi-ts.config.ts
+++ b/openapi-ts.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   plugins: [
     {
-      name: "@hey-api/client-axios",
+      name: "@hey-api/client-fetch",
       runtimeConfigPath: "./src/hey-api.ts"
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "@tanstack/react-router-devtools": "^1.114.3",
         "@tanstack/react-table": "^8.21.2",
         "@tanstack/router-plugin": "^1.114.3",
-        "axios": "^1.10.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -3403,9 +3402,10 @@
       ]
     },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
@@ -5102,29 +5102,12 @@
         "node": ">=12"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
     "node_modules/attr-accept": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
       "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-dead-code-elimination": {
@@ -5304,19 +5287,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -5501,18 +5471,6 @@
       "license": "ISC",
       "bin": {
         "color-support": "bin.js"
-      }
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/commander": {
@@ -5839,15 +5797,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -5909,20 +5858,6 @@
         "url": "https://dotenvx.com"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.165",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.165.tgz",
@@ -5955,57 +5890,12 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/es-toolkit": {
       "version": "1.39.10",
@@ -6633,42 +6523,6 @@
       "license": "ISC",
       "peer": true
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -6716,15 +6570,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -6734,30 +6579,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-nonce": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
@@ -6765,19 +6586,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -6930,18 +6738,6 @@
         "csstype": "^3.0.10"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -6985,45 +6781,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -7706,15 +7463,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -7737,27 +7485,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -8233,12 +7960,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -8404,9 +8125,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9468,9 +9189,9 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
-      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -9977,9 +9698,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
-      "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@tanstack/react-router-devtools": "^1.114.3",
     "@tanstack/react-table": "^8.21.2",
     "@tanstack/router-plugin": "^1.114.3",
-    "axios": "^1.10.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src/client/@tanstack/react-query.gen.ts
+++ b/src/client/@tanstack/react-query.gen.ts
@@ -17,6 +17,7 @@ import {
   browseS3,
   bulkCreateSamples,
   changePassword,
+  chat,
   clearSamplesForRun,
   confirmPasswordReset,
   createApiKey,
@@ -151,6 +152,8 @@ import type {
   ChangePasswordData,
   ChangePasswordError,
   ChangePasswordResponse,
+  ChatData,
+  ChatError,
   ClearSamplesForRunData,
   ClearSamplesForRunError,
   ClearSamplesForRunResponse,
@@ -381,10 +384,9 @@ import type {
   VerifyEmailError,
   VerifyEmailResponse,
 } from '../types.gen'
-import type { AxiosError } from 'axios'
 
 export type QueryKey<TOptions extends Options> = [
-  Pick<TOptions, 'baseURL' | 'body' | 'headers' | 'path' | 'query'> & {
+  Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
     _id: string
     _infinite?: boolean
   },
@@ -397,8 +399,8 @@ const createQueryKey = <TOptions extends Options>(
 ): [QueryKey<TOptions>[0]] => {
   const params: QueryKey<TOptions>[0] = {
     _id: id,
-    baseURL: (options?.client ?? _heyApiClient).getConfig().baseURL,
-  }
+    baseUrl: (options?.client ?? _heyApiClient).getConfig().baseUrl,
+  } as QueryKey<TOptions>[0]
   if (infinite) {
     params._infinite = infinite
   }
@@ -517,12 +519,12 @@ export const registerMutation = (
   options?: Partial<Options<RegisterData>>,
 ): UseMutationOptions<
   RegisterResponse,
-  AxiosError<RegisterError>,
+  RegisterError,
   Options<RegisterData>
 > => {
   const mutationOptions: UseMutationOptions<
     RegisterResponse,
-    AxiosError<RegisterError>,
+    RegisterError,
     Options<RegisterData>
   > = {
     mutationFn: async (localOptions) => {
@@ -595,14 +597,10 @@ export const loginOptions = (options: Options<LoginData>) => {
  */
 export const loginMutation = (
   options?: Partial<Options<LoginData>>,
-): UseMutationOptions<
-  LoginResponse,
-  AxiosError<LoginError>,
-  Options<LoginData>
-> => {
+): UseMutationOptions<LoginResponse, LoginError, Options<LoginData>> => {
   const mutationOptions: UseMutationOptions<
     LoginResponse,
-    AxiosError<LoginError>,
+    LoginError,
     Options<LoginData>
   > = {
     mutationFn: async (localOptions) => {
@@ -673,12 +671,12 @@ export const refreshTokenMutation = (
   options?: Partial<Options<RefreshTokenData>>,
 ): UseMutationOptions<
   RefreshTokenResponse,
-  AxiosError<RefreshTokenError>,
+  RefreshTokenError,
   Options<RefreshTokenData>
 > => {
   const mutationOptions: UseMutationOptions<
     RefreshTokenResponse,
-    AxiosError<RefreshTokenError>,
+    RefreshTokenError,
     Options<RefreshTokenData>
   > = {
     mutationFn: async (localOptions) => {
@@ -741,14 +739,10 @@ export const logoutOptions = (options: Options<LogoutData>) => {
  */
 export const logoutMutation = (
   options?: Partial<Options<LogoutData>>,
-): UseMutationOptions<
-  LogoutResponse,
-  AxiosError<LogoutError>,
-  Options<LogoutData>
-> => {
+): UseMutationOptions<LogoutResponse, LogoutError, Options<LogoutData>> => {
   const mutationOptions: UseMutationOptions<
     LogoutResponse,
-    AxiosError<LogoutError>,
+    LogoutError,
     Options<LogoutData>
   > = {
     mutationFn: async (localOptions) => {
@@ -853,12 +847,12 @@ export const requestPasswordResetMutation = (
   options?: Partial<Options<RequestPasswordResetData>>,
 ): UseMutationOptions<
   RequestPasswordResetResponse,
-  AxiosError<RequestPasswordResetError>,
+  RequestPasswordResetError,
   Options<RequestPasswordResetData>
 > => {
   const mutationOptions: UseMutationOptions<
     RequestPasswordResetResponse,
-    AxiosError<RequestPasswordResetError>,
+    RequestPasswordResetError,
     Options<RequestPasswordResetData>
   > = {
     mutationFn: async (localOptions) => {
@@ -930,12 +924,12 @@ export const confirmPasswordResetMutation = (
   options?: Partial<Options<ConfirmPasswordResetData>>,
 ): UseMutationOptions<
   ConfirmPasswordResetResponse,
-  AxiosError<ConfirmPasswordResetError>,
+  ConfirmPasswordResetError,
   Options<ConfirmPasswordResetData>
 > => {
   const mutationOptions: UseMutationOptions<
     ConfirmPasswordResetResponse,
-    AxiosError<ConfirmPasswordResetError>,
+    ConfirmPasswordResetError,
     Options<ConfirmPasswordResetData>
   > = {
     mutationFn: async (localOptions) => {
@@ -1010,12 +1004,12 @@ export const changePasswordMutation = (
   options?: Partial<Options<ChangePasswordData>>,
 ): UseMutationOptions<
   ChangePasswordResponse,
-  AxiosError<ChangePasswordError>,
+  ChangePasswordError,
   Options<ChangePasswordData>
 > => {
   const mutationOptions: UseMutationOptions<
     ChangePasswordResponse,
-    AxiosError<ChangePasswordError>,
+    ChangePasswordError,
     Options<ChangePasswordData>
   > = {
     mutationFn: async (localOptions) => {
@@ -1084,12 +1078,12 @@ export const verifyEmailMutation = (
   options?: Partial<Options<VerifyEmailData>>,
 ): UseMutationOptions<
   VerifyEmailResponse,
-  AxiosError<VerifyEmailError>,
+  VerifyEmailError,
   Options<VerifyEmailData>
 > => {
   const mutationOptions: UseMutationOptions<
     VerifyEmailResponse,
-    AxiosError<VerifyEmailError>,
+    VerifyEmailError,
     Options<VerifyEmailData>
   > = {
     mutationFn: async (localOptions) => {
@@ -1163,12 +1157,12 @@ export const resendVerificationMutation = (
   options?: Partial<Options<ResendVerificationData>>,
 ): UseMutationOptions<
   ResendVerificationResponse,
-  AxiosError<ResendVerificationError>,
+  ResendVerificationError,
   Options<ResendVerificationData>
 > => {
   const mutationOptions: UseMutationOptions<
     ResendVerificationResponse,
-    AxiosError<ResendVerificationError>,
+    ResendVerificationError,
     Options<ResendVerificationData>
   > = {
     mutationFn: async (localOptions) => {
@@ -1255,7 +1249,7 @@ export const listApiKeysInfiniteOptions = (
 ) => {
   return infiniteQueryOptions<
     ListApiKeysResponse,
-    AxiosError<ListApiKeysError>,
+    ListApiKeysError,
     InfiniteData<ListApiKeysResponse>,
     QueryKey<Options<ListApiKeysData>>,
     | number
@@ -1323,12 +1317,12 @@ export const createApiKeyMutation = (
   options?: Partial<Options<CreateApiKeyData>>,
 ): UseMutationOptions<
   CreateApiKeyResponse,
-  AxiosError<CreateApiKeyError>,
+  CreateApiKeyError,
   Options<CreateApiKeyData>
 > => {
   const mutationOptions: UseMutationOptions<
     CreateApiKeyResponse,
-    AxiosError<CreateApiKeyError>,
+    CreateApiKeyError,
     Options<CreateApiKeyData>
   > = {
     mutationFn: async (localOptions) => {
@@ -1351,12 +1345,12 @@ export const deleteApiKeyMutation = (
   options?: Partial<Options<DeleteApiKeyData>>,
 ): UseMutationOptions<
   DeleteApiKeyResponse,
-  AxiosError<DeleteApiKeyError>,
+  DeleteApiKeyError,
   Options<DeleteApiKeyData>
 > => {
   const mutationOptions: UseMutationOptions<
     DeleteApiKeyResponse,
-    AxiosError<DeleteApiKeyError>,
+    DeleteApiKeyError,
     Options<DeleteApiKeyData>
   > = {
     mutationFn: async (localOptions) => {
@@ -1401,12 +1395,12 @@ export const revokeApiKeyMutation = (
   options?: Partial<Options<RevokeApiKeyData>>,
 ): UseMutationOptions<
   RevokeApiKeyResponse,
-  AxiosError<RevokeApiKeyError>,
+  RevokeApiKeyError,
   Options<RevokeApiKeyData>
 > => {
   const mutationOptions: UseMutationOptions<
     RevokeApiKeyResponse,
-    AxiosError<RevokeApiKeyError>,
+    RevokeApiKeyError,
     Options<RevokeApiKeyData>
   > = {
     mutationFn: async (localOptions) => {
@@ -1588,12 +1582,12 @@ export const linkOauthProviderMutation = (
   options?: Partial<Options<LinkOauthProviderData>>,
 ): UseMutationOptions<
   LinkOauthProviderResponse,
-  AxiosError<LinkOauthProviderError>,
+  LinkOauthProviderError,
   Options<LinkOauthProviderData>
 > => {
   const mutationOptions: UseMutationOptions<
     LinkOauthProviderResponse,
-    AxiosError<LinkOauthProviderError>,
+    LinkOauthProviderError,
     Options<LinkOauthProviderData>
   > = {
     mutationFn: async (localOptions) => {
@@ -1632,12 +1626,12 @@ export const unlinkOauthProviderMutation = (
   options?: Partial<Options<UnlinkOauthProviderData>>,
 ): UseMutationOptions<
   UnlinkOauthProviderResponse,
-  AxiosError<UnlinkOauthProviderError>,
+  UnlinkOauthProviderError,
   Options<UnlinkOauthProviderData>
 > => {
   const mutationOptions: UseMutationOptions<
     UnlinkOauthProviderResponse,
-    AxiosError<UnlinkOauthProviderError>,
+    UnlinkOauthProviderError,
     Options<UnlinkOauthProviderData>
   > = {
     mutationFn: async (localOptions) => {
@@ -1740,12 +1734,12 @@ export const validateActionConfigMutation = (
   options?: Partial<Options<ValidateActionConfigData>>,
 ): UseMutationOptions<
   ValidateActionConfigResponse,
-  AxiosError<ValidateActionConfigError>,
+  ValidateActionConfigError,
   Options<ValidateActionConfigData>
 > => {
   const mutationOptions: UseMutationOptions<
     ValidateActionConfigResponse,
-    AxiosError<ValidateActionConfigError>,
+    ValidateActionConfigError,
     Options<ValidateActionConfigData>
   > = {
     mutationFn: async (localOptions) => {
@@ -1846,6 +1840,52 @@ export const getActionTypesOptions = (options: Options<GetActionTypesData>) => {
   })
 }
 
+export const chatQueryKey = (options: Options<ChatData>) =>
+  createQueryKey('chat', options)
+
+/**
+ * Chat
+ * Stream an assistant reply for the given message history.
+ */
+export const chatOptions = (options: Options<ChatData>) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await chat({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      })
+      return data
+    },
+    queryKey: chatQueryKey(options),
+  })
+}
+
+/**
+ * Chat
+ * Stream an assistant reply for the given message history.
+ */
+export const chatMutation = (
+  options?: Partial<Options<ChatData>>,
+): UseMutationOptions<unknown, ChatError, Options<ChatData>> => {
+  const mutationOptions: UseMutationOptions<
+    unknown,
+    ChatError,
+    Options<ChatData>
+  > = {
+    mutationFn: async (localOptions) => {
+      const { data } = await chat({
+        ...options,
+        ...localOptions,
+        throwOnError: true,
+      })
+      return data
+    },
+  }
+  return mutationOptions
+}
+
 export const listFilesQueryKey = (options?: Options<ListFilesData>) =>
   createQueryKey('listFiles', options)
 
@@ -1892,7 +1932,7 @@ export const listFilesInfiniteQueryKey = (
 export const listFilesInfiniteOptions = (options?: Options<ListFilesData>) => {
   return infiniteQueryOptions<
     ListFilesResponse,
-    AxiosError<ListFilesError>,
+    ListFilesError,
     InfiniteData<ListFilesResponse>,
     QueryKey<Options<ListFilesData>>,
     | number
@@ -1994,12 +2034,12 @@ export const createFileMutation = (
   options?: Partial<Options<CreateFileData>>,
 ): UseMutationOptions<
   CreateFileResponse,
-  AxiosError<CreateFileError>,
+  CreateFileError,
   Options<CreateFileData>
 > => {
   const mutationOptions: UseMutationOptions<
     CreateFileResponse,
-    AxiosError<CreateFileError>,
+    CreateFileError,
     Options<CreateFileData>
   > = {
     mutationFn: async (localOptions) => {
@@ -2082,12 +2122,12 @@ export const uploadFileMutation = (
   options?: Partial<Options<UploadFileData>>,
 ): UseMutationOptions<
   UploadFileResponse,
-  AxiosError<UploadFileError>,
+  UploadFileError,
   Options<UploadFileData>
 > => {
   const mutationOptions: UseMutationOptions<
     UploadFileResponse,
-    AxiosError<UploadFileError>,
+    UploadFileError,
     Options<UploadFileData>
   > = {
     mutationFn: async (localOptions) => {
@@ -2168,12 +2208,12 @@ export const deleteFileMutation = (
   options?: Partial<Options<DeleteFileData>>,
 ): UseMutationOptions<
   DeleteFileResponse,
-  AxiosError<DeleteFileError>,
+  DeleteFileError,
   Options<DeleteFileData>
 > => {
   const mutationOptions: UseMutationOptions<
     DeleteFileResponse,
-    AxiosError<DeleteFileError>,
+    DeleteFileError,
     Options<DeleteFileData>
   > = {
     mutationFn: async (localOptions) => {
@@ -2228,12 +2268,12 @@ export const updateFileMutation = (
   options?: Partial<Options<UpdateFileData>>,
 ): UseMutationOptions<
   UpdateFileResponse,
-  AxiosError<UpdateFileError>,
+  UpdateFileError,
   Options<UpdateFileData>
 > => {
   const mutationOptions: UseMutationOptions<
     UpdateFileResponse,
-    AxiosError<UpdateFileError>,
+    UpdateFileError,
     Options<UpdateFileData>
   > = {
     mutationFn: async (localOptions) => {
@@ -2361,12 +2401,12 @@ export const submitJobMutation = (
   options?: Partial<Options<SubmitJobData>>,
 ): UseMutationOptions<
   SubmitJobResponse,
-  AxiosError<SubmitJobError>,
+  SubmitJobError,
   Options<SubmitJobData>
 > => {
   const mutationOptions: UseMutationOptions<
     SubmitJobResponse,
-    AxiosError<SubmitJobError>,
+    SubmitJobError,
     Options<SubmitJobData>
   > = {
     mutationFn: async (localOptions) => {
@@ -2426,12 +2466,12 @@ export const updateJobMutation = (
   options?: Partial<Options<UpdateJobData>>,
 ): UseMutationOptions<
   UpdateJobResponse,
-  AxiosError<UpdateJobError>,
+  UpdateJobError,
   Options<UpdateJobData>
 > => {
   const mutationOptions: UseMutationOptions<
     UpdateJobResponse,
-    AxiosError<UpdateJobError>,
+    UpdateJobError,
     Options<UpdateJobData>
   > = {
     mutationFn: async (localOptions) => {
@@ -2600,12 +2640,12 @@ export const uploadManifestMutation = (
   options?: Partial<Options<UploadManifestData>>,
 ): UseMutationOptions<
   UploadManifestResponse,
-  AxiosError<UploadManifestError>,
+  UploadManifestError,
   Options<UploadManifestData>
 > => {
   const mutationOptions: UseMutationOptions<
     UploadManifestResponse,
-    AxiosError<UploadManifestError>,
+    UploadManifestError,
     Options<UploadManifestData>
   > = {
     mutationFn: async (localOptions) => {
@@ -2681,12 +2721,12 @@ export const validateManifestMutation = (
   options?: Partial<Options<ValidateManifestData>>,
 ): UseMutationOptions<
   ValidateManifestResponse,
-  AxiosError<ValidateManifestError>,
+  ValidateManifestError,
   Options<ValidateManifestData>
 > => {
   const mutationOptions: UseMutationOptions<
     ValidateManifestResponse,
-    AxiosError<ValidateManifestError>,
+    ValidateManifestError,
     Options<ValidateManifestData>
   > = {
     mutationFn: async (localOptions) => {
@@ -2737,7 +2777,7 @@ export const getProjectsInfiniteOptions = (
 ) => {
   return infiniteQueryOptions<
     GetProjectsResponse,
-    AxiosError<GetProjectsError>,
+    GetProjectsError,
     InfiniteData<GetProjectsResponse>,
     QueryKey<Options<GetProjectsData>>,
     | number
@@ -2805,12 +2845,12 @@ export const createProjectMutation = (
   options?: Partial<Options<CreateProjectData>>,
 ): UseMutationOptions<
   CreateProjectResponse,
-  AxiosError<CreateProjectError>,
+  CreateProjectError,
   Options<CreateProjectData>
 > => {
   const mutationOptions: UseMutationOptions<
     CreateProjectResponse,
-    AxiosError<CreateProjectError>,
+    CreateProjectError,
     Options<CreateProjectData>
   > = {
     mutationFn: async (localOptions) => {
@@ -2890,7 +2930,7 @@ export const searchProjectsInfiniteOptions = (
 ) => {
   return infiniteQueryOptions<
     SearchProjectsResponse,
-    AxiosError<SearchProjectsError>,
+    SearchProjectsError,
     InfiniteData<SearchProjectsResponse>,
     QueryKey<Options<SearchProjectsData>>,
     | number
@@ -2959,14 +2999,10 @@ export const reindexProjectsOptions = (
  */
 export const reindexProjectsMutation = (
   options?: Partial<Options<ReindexProjectsData>>,
-): UseMutationOptions<
-  unknown,
-  AxiosError<DefaultError>,
-  Options<ReindexProjectsData>
-> => {
+): UseMutationOptions<unknown, DefaultError, Options<ReindexProjectsData>> => {
   const mutationOptions: UseMutationOptions<
     unknown,
-    AxiosError<DefaultError>,
+    DefaultError,
     Options<ReindexProjectsData>
   > = {
     mutationFn: async (localOptions) => {
@@ -3020,12 +3056,12 @@ export const patchProjectMutation = (
   options?: Partial<Options<PatchProjectData>>,
 ): UseMutationOptions<
   PatchProjectResponse,
-  AxiosError<PatchProjectError>,
+  PatchProjectError,
   Options<PatchProjectData>
 > => {
   const mutationOptions: UseMutationOptions<
     PatchProjectResponse,
-    AxiosError<PatchProjectError>,
+    PatchProjectError,
     Options<PatchProjectData>
   > = {
     mutationFn: async (localOptions) => {
@@ -3052,12 +3088,12 @@ export const updateProjectMutation = (
   options?: Partial<Options<UpdateProjectData>>,
 ): UseMutationOptions<
   UpdateProjectResponse,
-  AxiosError<UpdateProjectError>,
+  UpdateProjectError,
   Options<UpdateProjectData>
 > => {
   const mutationOptions: UseMutationOptions<
     UpdateProjectResponse,
-    AxiosError<UpdateProjectError>,
+    UpdateProjectError,
     Options<UpdateProjectData>
   > = {
     mutationFn: async (localOptions) => {
@@ -3143,12 +3179,12 @@ export const addSampleToProjectMutation = (
   options?: Partial<Options<AddSampleToProjectData>>,
 ): UseMutationOptions<
   AddSampleToProjectResponse,
-  AxiosError<AddSampleToProjectError>,
+  AddSampleToProjectError,
   Options<AddSampleToProjectData>
 > => {
   const mutationOptions: UseMutationOptions<
     AddSampleToProjectResponse,
-    AxiosError<AddSampleToProjectError>,
+    AddSampleToProjectError,
     Options<AddSampleToProjectData>
   > = {
     mutationFn: async (localOptions) => {
@@ -3212,12 +3248,12 @@ export const uploadSamplesFileMutation = (
   options?: Partial<Options<UploadSamplesFileData>>,
 ): UseMutationOptions<
   UploadSamplesFileResponse,
-  AxiosError<UploadSamplesFileError>,
+  UploadSamplesFileError,
   Options<UploadSamplesFileData>
 > => {
   const mutationOptions: UseMutationOptions<
     UploadSamplesFileResponse,
-    AxiosError<UploadSamplesFileError>,
+    UploadSamplesFileError,
     Options<UploadSamplesFileData>
   > = {
     mutationFn: async (localOptions) => {
@@ -3273,12 +3309,12 @@ export const bulkCreateSamplesMutation = (
   options?: Partial<Options<BulkCreateSamplesData>>,
 ): UseMutationOptions<
   BulkCreateSamplesResponse,
-  AxiosError<BulkCreateSamplesError>,
+  BulkCreateSamplesError,
   Options<BulkCreateSamplesData>
 > => {
   const mutationOptions: UseMutationOptions<
     BulkCreateSamplesResponse,
-    AxiosError<BulkCreateSamplesError>,
+    BulkCreateSamplesError,
     Options<BulkCreateSamplesData>
   > = {
     mutationFn: async (localOptions) => {
@@ -3306,12 +3342,12 @@ export const deleteSampleFromProjectMutation = (
   options?: Partial<Options<DeleteSampleFromProjectData>>,
 ): UseMutationOptions<
   DeleteSampleFromProjectResponse,
-  AxiosError<DeleteSampleFromProjectError>,
+  DeleteSampleFromProjectError,
   Options<DeleteSampleFromProjectData>
 > => {
   const mutationOptions: UseMutationOptions<
     DeleteSampleFromProjectResponse,
-    AxiosError<DeleteSampleFromProjectError>,
+    DeleteSampleFromProjectError,
     Options<DeleteSampleFromProjectData>
   > = {
     mutationFn: async (localOptions) => {
@@ -3334,12 +3370,12 @@ export const updateSampleInProjectMutation = (
   options?: Partial<Options<UpdateSampleInProjectData>>,
 ): UseMutationOptions<
   UpdateSampleInProjectResponse,
-  AxiosError<UpdateSampleInProjectError>,
+  UpdateSampleInProjectError,
   Options<UpdateSampleInProjectData>
 > => {
   const mutationOptions: UseMutationOptions<
     UpdateSampleInProjectResponse,
-    AxiosError<UpdateSampleInProjectError>,
+    UpdateSampleInProjectError,
     Options<UpdateSampleInProjectData>
   > = {
     mutationFn: async (localOptions) => {
@@ -3427,12 +3463,12 @@ export const submitPipelineJobMutation = (
   options?: Partial<Options<SubmitPipelineJobData>>,
 ): UseMutationOptions<
   SubmitPipelineJobResponse,
-  AxiosError<SubmitPipelineJobError>,
+  SubmitPipelineJobError,
   Options<SubmitPipelineJobData>
 > => {
   const mutationOptions: UseMutationOptions<
     SubmitPipelineJobResponse,
-    AxiosError<SubmitPipelineJobError>,
+    SubmitPipelineJobError,
     Options<SubmitPipelineJobData>
   > = {
     mutationFn: async (localOptions) => {
@@ -3486,12 +3522,12 @@ export const ingestVendorDataMutation = (
   options?: Partial<Options<IngestVendorDataData>>,
 ): UseMutationOptions<
   IngestVendorDataResponse,
-  AxiosError<IngestVendorDataError>,
+  IngestVendorDataError,
   Options<IngestVendorDataData>
 > => {
   const mutationOptions: UseMutationOptions<
     IngestVendorDataResponse,
-    AxiosError<IngestVendorDataError>,
+    IngestVendorDataError,
     Options<IngestVendorDataData>
   > = {
     mutationFn: async (localOptions) => {
@@ -3640,12 +3676,12 @@ export const createQcrecordMutation = (
   options?: Partial<Options<CreateQcrecordData>>,
 ): UseMutationOptions<
   CreateQcrecordResponse,
-  AxiosError<CreateQcrecordError>,
+  CreateQcrecordError,
   Options<CreateQcrecordData>
 > => {
   const mutationOptions: UseMutationOptions<
     CreateQcrecordResponse,
-    AxiosError<CreateQcrecordError>,
+    CreateQcrecordError,
     Options<CreateQcrecordData>
   > = {
     mutationFn: async (localOptions) => {
@@ -3729,7 +3765,7 @@ export const searchQcrecordsGetInfiniteOptions = (
 ) => {
   return infiniteQueryOptions<
     SearchQcrecordsGetResponse,
-    AxiosError<SearchQcrecordsGetError>,
+    SearchQcrecordsGetError,
     InfiniteData<SearchQcrecordsGetResponse>,
     QueryKey<Options<SearchQcrecordsGetData>>,
     | number
@@ -3864,7 +3900,7 @@ export const searchQcrecordsPostInfiniteOptions = (
 ) => {
   return infiniteQueryOptions<
     SearchQcrecordsPostResponse,
-    AxiosError<SearchQcrecordsPostError>,
+    SearchQcrecordsPostError,
     InfiniteData<SearchQcrecordsPostResponse>,
     QueryKey<Options<SearchQcrecordsPostData>>,
     | number
@@ -3939,12 +3975,12 @@ export const searchQcrecordsPostMutation = (
   options?: Partial<Options<SearchQcrecordsPostData>>,
 ): UseMutationOptions<
   SearchQcrecordsPostResponse,
-  AxiosError<SearchQcrecordsPostError>,
+  SearchQcrecordsPostError,
   Options<SearchQcrecordsPostData>
 > => {
   const mutationOptions: UseMutationOptions<
     SearchQcrecordsPostResponse,
-    AxiosError<SearchQcrecordsPostError>,
+    SearchQcrecordsPostError,
     Options<SearchQcrecordsPostData>
   > = {
     mutationFn: async (localOptions) => {
@@ -3975,12 +4011,12 @@ export const deleteQcrecordMutation = (
   options?: Partial<Options<DeleteQcrecordData>>,
 ): UseMutationOptions<
   DeleteQcrecordResponse,
-  AxiosError<DeleteQcrecordError>,
+  DeleteQcrecordError,
   Options<DeleteQcrecordData>
 > => {
   const mutationOptions: UseMutationOptions<
     DeleteQcrecordResponse,
-    AxiosError<DeleteQcrecordError>,
+    DeleteQcrecordError,
     Options<DeleteQcrecordData>
   > = {
     mutationFn: async (localOptions) => {
@@ -4052,7 +4088,7 @@ export const getRunsInfiniteQueryKey = (
 export const getRunsInfiniteOptions = (options?: Options<GetRunsData>) => {
   return infiniteQueryOptions<
     GetRunsResponse,
-    AxiosError<GetRunsError>,
+    GetRunsError,
     InfiniteData<GetRunsResponse>,
     QueryKey<Options<GetRunsData>>,
     | number
@@ -4118,14 +4154,10 @@ export const addRunOptions = (options: Options<AddRunData>) => {
  */
 export const addRunMutation = (
   options?: Partial<Options<AddRunData>>,
-): UseMutationOptions<
-  AddRunResponse,
-  AxiosError<AddRunError>,
-  Options<AddRunData>
-> => {
+): UseMutationOptions<AddRunResponse, AddRunError, Options<AddRunData>> => {
   const mutationOptions: UseMutationOptions<
     AddRunResponse,
-    AxiosError<AddRunError>,
+    AddRunError,
     Options<AddRunData>
   > = {
     mutationFn: async (localOptions) => {
@@ -4174,7 +4206,7 @@ export const searchRunsInfiniteQueryKey = (
 export const searchRunsInfiniteOptions = (options: Options<SearchRunsData>) => {
   return infiniteQueryOptions<
     SearchRunsResponse,
-    AxiosError<SearchRunsError>,
+    SearchRunsError,
     InfiniteData<SearchRunsResponse>,
     QueryKey<Options<SearchRunsData>>,
     | number
@@ -4240,14 +4272,10 @@ export const reindexRunsOptions = (options?: Options<ReindexRunsData>) => {
  */
 export const reindexRunsMutation = (
   options?: Partial<Options<ReindexRunsData>>,
-): UseMutationOptions<
-  unknown,
-  AxiosError<DefaultError>,
-  Options<ReindexRunsData>
-> => {
+): UseMutationOptions<unknown, DefaultError, Options<ReindexRunsData>> => {
   const mutationOptions: UseMutationOptions<
     unknown,
-    AxiosError<DefaultError>,
+    DefaultError,
     Options<ReindexRunsData>
   > = {
     mutationFn: async (localOptions) => {
@@ -4336,12 +4364,12 @@ export const submitDemultiplexWorkflowJobMutation = (
   options?: Partial<Options<SubmitDemultiplexWorkflowJobData>>,
 ): UseMutationOptions<
   SubmitDemultiplexWorkflowJobResponse,
-  AxiosError<SubmitDemultiplexWorkflowJobError>,
+  SubmitDemultiplexWorkflowJobError,
   Options<SubmitDemultiplexWorkflowJobData>
 > => {
   const mutationOptions: UseMutationOptions<
     SubmitDemultiplexWorkflowJobResponse,
-    AxiosError<SubmitDemultiplexWorkflowJobError>,
+    SubmitDemultiplexWorkflowJobError,
     Options<SubmitDemultiplexWorkflowJobData>
   > = {
     mutationFn: async (localOptions) => {
@@ -4419,12 +4447,12 @@ export const updateRunMutation = (
   options?: Partial<Options<UpdateRunData>>,
 ): UseMutationOptions<
   UpdateRunResponse,
-  AxiosError<UpdateRunError>,
+  UpdateRunError,
   Options<UpdateRunData>
 > => {
   const mutationOptions: UseMutationOptions<
     UpdateRunResponse,
-    AxiosError<UpdateRunError>,
+    UpdateRunError,
     Options<UpdateRunData>
   > = {
     mutationFn: async (localOptions) => {
@@ -4497,12 +4525,12 @@ export const postRunSamplesheetMutation = (
   options?: Partial<Options<PostRunSamplesheetData>>,
 ): UseMutationOptions<
   PostRunSamplesheetResponse,
-  AxiosError<PostRunSamplesheetError>,
+  PostRunSamplesheetError,
   Options<PostRunSamplesheetData>
 > => {
   const mutationOptions: UseMutationOptions<
     PostRunSamplesheetResponse,
-    AxiosError<PostRunSamplesheetError>,
+    PostRunSamplesheetError,
     Options<PostRunSamplesheetData>
   > = {
     mutationFn: async (localOptions) => {
@@ -4552,12 +4580,12 @@ export const clearSamplesForRunMutation = (
   options?: Partial<Options<ClearSamplesForRunData>>,
 ): UseMutationOptions<
   ClearSamplesForRunResponse,
-  AxiosError<ClearSamplesForRunError>,
+  ClearSamplesForRunError,
   Options<ClearSamplesForRunData>
 > => {
   const mutationOptions: UseMutationOptions<
     ClearSamplesForRunResponse,
-    AxiosError<ClearSamplesForRunError>,
+    ClearSamplesForRunError,
     Options<ClearSamplesForRunData>
   > = {
     mutationFn: async (localOptions) => {
@@ -4630,12 +4658,12 @@ export const associateSampleWithRunMutation = (
   options?: Partial<Options<AssociateSampleWithRunData>>,
 ): UseMutationOptions<
   AssociateSampleWithRunResponse,
-  AxiosError<AssociateSampleWithRunError>,
+  AssociateSampleWithRunError,
   Options<AssociateSampleWithRunData>
 > => {
   const mutationOptions: UseMutationOptions<
     AssociateSampleWithRunResponse,
-    AxiosError<AssociateSampleWithRunError>,
+    AssociateSampleWithRunError,
     Options<AssociateSampleWithRunData>
   > = {
     mutationFn: async (localOptions) => {
@@ -4658,12 +4686,12 @@ export const removeSampleFromRunMutation = (
   options?: Partial<Options<RemoveSampleFromRunData>>,
 ): UseMutationOptions<
   RemoveSampleFromRunResponse,
-  AxiosError<RemoveSampleFromRunError>,
+  RemoveSampleFromRunError,
   Options<RemoveSampleFromRunData>
 > => {
   const mutationOptions: UseMutationOptions<
     RemoveSampleFromRunResponse,
-    AxiosError<RemoveSampleFromRunError>,
+    RemoveSampleFromRunError,
     Options<RemoveSampleFromRunData>
   > = {
     mutationFn: async (localOptions) => {
@@ -4692,7 +4720,7 @@ export const searchSamplesGetQueryKey = (
  * Supported filter keys:
  * - ``projectid``: exact match on project ID
  * - ``samplename``: exact match on sample name
- * - ``created_on``: date prefix match (YYYY-MM-DD) on created_at
+ * - ``created_at``: date prefix match (YYYY-MM-DD) on created_at
  * - Any other key: matched against sample attributes (case-insensitive key)
  *
  * Multiple filters are AND'd together.
@@ -4729,7 +4757,7 @@ export const searchSamplesGetInfiniteQueryKey = (
  * Supported filter keys:
  * - ``projectid``: exact match on project ID
  * - ``samplename``: exact match on sample name
- * - ``created_on``: date prefix match (YYYY-MM-DD) on created_at
+ * - ``created_at``: date prefix match (YYYY-MM-DD) on created_at
  * - Any other key: matched against sample attributes (case-insensitive key)
  *
  * Multiple filters are AND'd together.
@@ -4739,7 +4767,7 @@ export const searchSamplesGetInfiniteOptions = (
 ) => {
   return infiniteQueryOptions<
     SearchSamplesGetResponse,
-    AxiosError<SearchSamplesGetError>,
+    SearchSamplesGetError,
     InfiniteData<SearchSamplesGetResponse>,
     QueryKey<Options<SearchSamplesGetData>>,
     | number
@@ -4801,7 +4829,7 @@ export const searchSamplesPostQueryKey = (
  * ``filter_on`` supports:
  * - ``projectid`` (str or list)
  * - ``samplename`` (str or list)
- * - ``created_on`` (str, date prefix match)
+ * - ``created_at`` (str, date prefix match)
  * - ``tags`` (dict of key/value pairs, matched case-insensitively)
  * - Any other key is matched against sample attributes
  *
@@ -4849,7 +4877,7 @@ export const searchSamplesPostInfiniteQueryKey = (
  * ``filter_on`` supports:
  * - ``projectid`` (str or list)
  * - ``samplename`` (str or list)
- * - ``created_on`` (str, date prefix match)
+ * - ``created_at`` (str, date prefix match)
  * - ``tags`` (dict of key/value pairs, matched case-insensitively)
  * - Any other key is matched against sample attributes
  *
@@ -4860,7 +4888,7 @@ export const searchSamplesPostInfiniteOptions = (
 ) => {
   return infiniteQueryOptions<
     SearchSamplesPostResponse,
-    AxiosError<SearchSamplesPostError>,
+    SearchSamplesPostError,
     InfiniteData<SearchSamplesPostResponse>,
     QueryKey<Options<SearchSamplesPostData>>,
     | number
@@ -4918,7 +4946,7 @@ export const searchSamplesPostInfiniteOptions = (
  * ``filter_on`` supports:
  * - ``projectid`` (str or list)
  * - ``samplename`` (str or list)
- * - ``created_on`` (str, date prefix match)
+ * - ``created_at`` (str, date prefix match)
  * - ``tags`` (dict of key/value pairs, matched case-insensitively)
  * - Any other key is matched against sample attributes
  *
@@ -4928,12 +4956,12 @@ export const searchSamplesPostMutation = (
   options?: Partial<Options<SearchSamplesPostData>>,
 ): UseMutationOptions<
   SearchSamplesPostResponse,
-  AxiosError<SearchSamplesPostError>,
+  SearchSamplesPostError,
   Options<SearchSamplesPostData>
 > => {
   const mutationOptions: UseMutationOptions<
     SearchSamplesPostResponse,
-    AxiosError<SearchSamplesPostError>,
+    SearchSamplesPostError,
     Options<SearchSamplesPostData>
   > = {
     mutationFn: async (localOptions) => {
@@ -4978,14 +5006,10 @@ export const reindexSamplesOptions = (
  */
 export const reindexSamplesMutation = (
   options?: Partial<Options<ReindexSamplesData>>,
-): UseMutationOptions<
-  unknown,
-  AxiosError<DefaultError>,
-  Options<ReindexSamplesData>
-> => {
+): UseMutationOptions<unknown, DefaultError, Options<ReindexSamplesData>> => {
   const mutationOptions: UseMutationOptions<
     unknown,
-    AxiosError<DefaultError>,
+    DefaultError,
     Options<ReindexSamplesData>
   > = {
     mutationFn: async (localOptions) => {
@@ -5079,12 +5103,12 @@ export const updateSettingMutation = (
   options?: Partial<Options<UpdateSettingData>>,
 ): UseMutationOptions<
   UpdateSettingResponse,
-  AxiosError<UpdateSettingError>,
+  UpdateSettingError,
   Options<UpdateSettingData>
 > => {
   const mutationOptions: UseMutationOptions<
     UpdateSettingResponse,
-    AxiosError<UpdateSettingError>,
+    UpdateSettingError,
     Options<UpdateSettingData>
   > = {
     mutationFn: async (localOptions) => {
@@ -5151,12 +5175,12 @@ export const addVendorMutation = (
   options?: Partial<Options<AddVendorData>>,
 ): UseMutationOptions<
   AddVendorResponse,
-  AxiosError<AddVendorError>,
+  AddVendorError,
   Options<AddVendorData>
 > => {
   const mutationOptions: UseMutationOptions<
     AddVendorResponse,
-    AxiosError<AddVendorError>,
+    AddVendorError,
     Options<AddVendorData>
   > = {
     mutationFn: async (localOptions) => {
@@ -5179,12 +5203,12 @@ export const deleteVendorMutation = (
   options?: Partial<Options<DeleteVendorData>>,
 ): UseMutationOptions<
   DeleteVendorResponse,
-  AxiosError<DeleteVendorError>,
+  DeleteVendorError,
   Options<DeleteVendorData>
 > => {
   const mutationOptions: UseMutationOptions<
     DeleteVendorResponse,
-    AxiosError<DeleteVendorError>,
+    DeleteVendorError,
     Options<DeleteVendorData>
   > = {
     mutationFn: async (localOptions) => {
@@ -5229,12 +5253,12 @@ export const updateVendorMutation = (
   options?: Partial<Options<UpdateVendorData>>,
 ): UseMutationOptions<
   UpdateVendorResponse,
-  AxiosError<UpdateVendorError>,
+  UpdateVendorError,
   Options<UpdateVendorData>
 > => {
   const mutationOptions: UseMutationOptions<
     UpdateVendorResponse,
-    AxiosError<UpdateVendorError>,
+    UpdateVendorError,
     Options<UpdateVendorData>
   > = {
     mutationFn: async (localOptions) => {
@@ -5285,7 +5309,7 @@ export const getWorkflowsInfiniteOptions = (
 ) => {
   return infiniteQueryOptions<
     GetWorkflowsResponse,
-    AxiosError<GetWorkflowsError>,
+    GetWorkflowsError,
     InfiniteData<GetWorkflowsResponse>,
     QueryKey<Options<GetWorkflowsData>>,
     | number
@@ -5353,12 +5377,12 @@ export const createWorkflowMutation = (
   options?: Partial<Options<CreateWorkflowData>>,
 ): UseMutationOptions<
   CreateWorkflowResponse,
-  AxiosError<CreateWorkflowError>,
+  CreateWorkflowError,
   Options<CreateWorkflowData>
 > => {
   const mutationOptions: UseMutationOptions<
     CreateWorkflowResponse,
-    AxiosError<CreateWorkflowError>,
+    CreateWorkflowError,
     Options<CreateWorkflowData>
   > = {
     mutationFn: async (localOptions) => {
@@ -5456,12 +5480,12 @@ export const createWorkflowVersionMutation = (
   options?: Partial<Options<CreateWorkflowVersionData>>,
 ): UseMutationOptions<
   CreateWorkflowVersionResponse,
-  AxiosError<CreateWorkflowVersionError>,
+  CreateWorkflowVersionError,
   Options<CreateWorkflowVersionData>
 > => {
   const mutationOptions: UseMutationOptions<
     CreateWorkflowVersionResponse,
-    AxiosError<CreateWorkflowVersionError>,
+    CreateWorkflowVersionError,
     Options<CreateWorkflowVersionData>
   > = {
     mutationFn: async (localOptions) => {
@@ -5509,12 +5533,12 @@ export const deleteWorkflowVersionAliasMutation = (
   options?: Partial<Options<DeleteWorkflowVersionAliasData>>,
 ): UseMutationOptions<
   DeleteWorkflowVersionAliasResponse,
-  AxiosError<DeleteWorkflowVersionAliasError>,
+  DeleteWorkflowVersionAliasError,
   Options<DeleteWorkflowVersionAliasData>
 > => {
   const mutationOptions: UseMutationOptions<
     DeleteWorkflowVersionAliasResponse,
-    AxiosError<DeleteWorkflowVersionAliasError>,
+    DeleteWorkflowVersionAliasError,
     Options<DeleteWorkflowVersionAliasData>
   > = {
     mutationFn: async (localOptions) => {
@@ -5537,12 +5561,12 @@ export const setWorkflowVersionAliasMutation = (
   options?: Partial<Options<SetWorkflowVersionAliasData>>,
 ): UseMutationOptions<
   SetWorkflowVersionAliasResponse,
-  AxiosError<SetWorkflowVersionAliasError>,
+  SetWorkflowVersionAliasError,
   Options<SetWorkflowVersionAliasData>
 > => {
   const mutationOptions: UseMutationOptions<
     SetWorkflowVersionAliasResponse,
-    AxiosError<SetWorkflowVersionAliasError>,
+    SetWorkflowVersionAliasError,
     Options<SetWorkflowVersionAliasData>
   > = {
     mutationFn: async (localOptions) => {
@@ -5673,12 +5697,12 @@ export const createWorkflowDeploymentMutation = (
   options?: Partial<Options<CreateWorkflowDeploymentData>>,
 ): UseMutationOptions<
   CreateWorkflowDeploymentResponse,
-  AxiosError<CreateWorkflowDeploymentError>,
+  CreateWorkflowDeploymentError,
   Options<CreateWorkflowDeploymentData>
 > => {
   const mutationOptions: UseMutationOptions<
     CreateWorkflowDeploymentResponse,
-    AxiosError<CreateWorkflowDeploymentError>,
+    CreateWorkflowDeploymentError,
     Options<CreateWorkflowDeploymentData>
   > = {
     mutationFn: async (localOptions) => {
@@ -5701,12 +5725,12 @@ export const deleteWorkflowDeploymentMutation = (
   options?: Partial<Options<DeleteWorkflowDeploymentData>>,
 ): UseMutationOptions<
   DeleteWorkflowDeploymentResponse,
-  AxiosError<DeleteWorkflowDeploymentError>,
+  DeleteWorkflowDeploymentError,
   Options<DeleteWorkflowDeploymentData>
 > => {
   const mutationOptions: UseMutationOptions<
     DeleteWorkflowDeploymentResponse,
-    AxiosError<DeleteWorkflowDeploymentError>,
+    DeleteWorkflowDeploymentError,
     Options<DeleteWorkflowDeploymentData>
   > = {
     mutationFn: async (localOptions) => {
@@ -5757,7 +5781,7 @@ export const getPipelinesInfiniteOptions = (
 ) => {
   return infiniteQueryOptions<
     GetPipelinesResponse,
-    AxiosError<GetPipelinesError>,
+    GetPipelinesError,
     InfiniteData<GetPipelinesResponse>,
     QueryKey<Options<GetPipelinesData>>,
     | number
@@ -5825,12 +5849,12 @@ export const createPipelineMutation = (
   options?: Partial<Options<CreatePipelineData>>,
 ): UseMutationOptions<
   CreatePipelineResponse,
-  AxiosError<CreatePipelineError>,
+  CreatePipelineError,
   Options<CreatePipelineData>
 > => {
   const mutationOptions: UseMutationOptions<
     CreatePipelineResponse,
-    AxiosError<CreatePipelineError>,
+    CreatePipelineError,
     Options<CreatePipelineData>
   > = {
     mutationFn: async (localOptions) => {
@@ -5903,12 +5927,12 @@ export const addWorkflowToPipelineMutation = (
   options?: Partial<Options<AddWorkflowToPipelineData>>,
 ): UseMutationOptions<
   AddWorkflowToPipelineResponse,
-  AxiosError<AddWorkflowToPipelineError>,
+  AddWorkflowToPipelineError,
   Options<AddWorkflowToPipelineData>
 > => {
   const mutationOptions: UseMutationOptions<
     AddWorkflowToPipelineResponse,
-    AxiosError<AddWorkflowToPipelineError>,
+    AddWorkflowToPipelineError,
     Options<AddWorkflowToPipelineData>
   > = {
     mutationFn: async (localOptions) => {
@@ -5931,12 +5955,12 @@ export const removeWorkflowFromPipelineMutation = (
   options?: Partial<Options<RemoveWorkflowFromPipelineData>>,
 ): UseMutationOptions<
   RemoveWorkflowFromPipelineResponse,
-  AxiosError<RemoveWorkflowFromPipelineError>,
+  RemoveWorkflowFromPipelineError,
   Options<RemoveWorkflowFromPipelineData>
 > => {
   const mutationOptions: UseMutationOptions<
     RemoveWorkflowFromPipelineResponse,
-    AxiosError<RemoveWorkflowFromPipelineError>,
+    RemoveWorkflowFromPipelineError,
     Options<RemoveWorkflowFromPipelineData>
   > = {
     mutationFn: async (localOptions) => {
@@ -6003,12 +6027,12 @@ export const createPlatformMutation = (
   options?: Partial<Options<CreatePlatformData>>,
 ): UseMutationOptions<
   CreatePlatformResponse,
-  AxiosError<CreatePlatformError>,
+  CreatePlatformError,
   Options<CreatePlatformData>
 > => {
   const mutationOptions: UseMutationOptions<
     CreatePlatformResponse,
-    AxiosError<CreatePlatformError>,
+    CreatePlatformError,
     Options<CreatePlatformData>
   > = {
     mutationFn: async (localOptions) => {

--- a/src/client/client.gen.ts
+++ b/src/client/client.gen.ts
@@ -26,7 +26,7 @@ export type CreateClientConfig<T extends DefaultClientOptions = ClientOptions> =
 export const client = createClient(
   createClientConfig(
     createConfig<ClientOptions>({
-      baseURL: 'http://apiserver:3000',
+      baseUrl: 'http://localhost:3000',
     }),
   ),
 )

--- a/src/client/client/client.ts
+++ b/src/client/client/client.ts
@@ -1,41 +1,41 @@
-import axios from 'axios'
 import {
   buildUrl,
   createConfig,
+  createInterceptors,
+  getParseAs,
   mergeConfigs,
   mergeHeaders,
   setAuthParams,
 } from './utils'
-import type { AxiosError, RawAxiosRequestHeaders } from 'axios'
+import type { Client, Config, RequestOptions } from './types'
 
-import type { Client, Config } from './types'
+type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
+  body?: any
+  headers: ReturnType<typeof mergeHeaders>
+}
 
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config)
-
-   
-  const { auth, ...configWithoutAuth } = _config
-  const instance = axios.create(configWithoutAuth)
 
   const getConfig = (): Config => ({ ..._config })
 
   const setConfig = (config: Config): Config => {
     _config = mergeConfigs(_config, config)
-    instance.defaults = {
-      ...instance.defaults,
-      ..._config,
-      // @ts-expect-error
-      headers: mergeHeaders(instance.defaults.headers, _config.headers),
-    }
     return getConfig()
   }
 
-  // @ts-expect-error
+  const interceptors = createInterceptors<
+    Request,
+    Response,
+    unknown,
+    RequestOptions
+  >()
+
   const request: Client['request'] = async (options) => {
     const opts = {
       ..._config,
       ...options,
-      axios: options.axios ?? _config.axios ?? instance,
+      fetch: options.fetch ?? _config.fetch ?? globalThis.fetch,
       headers: mergeHeaders(_config.headers, options.headers),
     }
 
@@ -54,26 +54,78 @@ export const createClient = (config: Config = {}): Client => {
       opts.body = opts.bodySerializer(opts.body)
     }
 
+    // remove Content-Type header if body is empty to avoid sending invalid requests
+    if (opts.body === undefined || opts.body === '') {
+      opts.headers.delete('Content-Type')
+    }
+
     const url = buildUrl(opts)
+    const requestInit: ReqInit = {
+      redirect: 'follow',
+      ...opts,
+    }
 
-    try {
-      // assign Axios here for consistency with fetch
-      const _axios = opts.axios
-       
-      const { auth, ...optsWithoutAuth } = opts
-      const response = await _axios({
-        ...optsWithoutAuth,
-        baseURL: opts.baseURL as string,
-        data: opts.body,
-        headers: opts.headers as RawAxiosRequestHeaders,
-        // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
-        url,
-      })
+    let request = new Request(url, requestInit)
 
-      let { data } = response
+    for (const fn of interceptors.request._fns) {
+      if (fn) {
+        request = await fn(request, opts)
+      }
+    }
 
-      if (opts.responseType === 'json') {
+    // fetch must be assigned here, otherwise it would throw the error:
+    // TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation
+    const _fetch = opts.fetch
+    let response = await _fetch(request)
+
+    for (const fn of interceptors.response._fns) {
+      if (fn) {
+        response = await fn(response, request, opts)
+      }
+    }
+
+    const result = {
+      request,
+      response,
+    }
+
+    if (response.ok) {
+      if (
+        response.status === 204 ||
+        response.headers.get('Content-Length') === '0'
+      ) {
+        return opts.responseStyle === 'data'
+          ? {}
+          : {
+              data: {},
+              ...result,
+            }
+      }
+
+      const parseAs =
+        (opts.parseAs === 'auto'
+          ? getParseAs(response.headers.get('Content-Type'))
+          : opts.parseAs) ?? 'json'
+
+      let data: any
+      switch (parseAs) {
+        case 'arrayBuffer':
+        case 'blob':
+        case 'formData':
+        case 'json':
+        case 'text':
+          data = await response[parseAs]()
+          break
+        case 'stream':
+          return opts.responseStyle === 'data'
+            ? response.body
+            : {
+                data: response.body,
+                ...result,
+              }
+      }
+
+      if (parseAs === 'json') {
         if (opts.responseValidator) {
           await opts.responseValidator(data)
         }
@@ -83,33 +135,61 @@ export const createClient = (config: Config = {}): Client => {
         }
       }
 
-      return {
-        ...response,
-        data: data ?? {},
-      }
-    } catch (error) {
-      const e = error as AxiosError
-      if (opts.throwOnError) {
-        throw e
-      }
-      // @ts-expect-error
-      e.error = e.response?.data ?? {}
-      return e
+      return opts.responseStyle === 'data'
+        ? data
+        : {
+            data,
+            ...result,
+          }
     }
+
+    const textError = await response.text()
+    let jsonError: unknown
+
+    try {
+      jsonError = JSON.parse(textError)
+    } catch {
+      // noop
+    }
+
+    const error = jsonError ?? textError
+    let finalError = error
+
+    for (const fn of interceptors.error._fns) {
+      if (fn) {
+        finalError = (await fn(error, response, request, opts)) as string
+      }
+    }
+
+    finalError = finalError || ({} as string)
+
+    if (opts.throwOnError) {
+      throw finalError
+    }
+
+    // TODO: we probably want to return error and improve types
+    return opts.responseStyle === 'data'
+      ? undefined
+      : {
+          error: finalError,
+          ...result,
+        }
   }
 
   return {
     buildUrl,
+    connect: (options) => request({ ...options, method: 'CONNECT' }),
     delete: (options) => request({ ...options, method: 'DELETE' }),
     get: (options) => request({ ...options, method: 'GET' }),
     getConfig,
     head: (options) => request({ ...options, method: 'HEAD' }),
-    instance,
+    interceptors,
     options: (options) => request({ ...options, method: 'OPTIONS' }),
     patch: (options) => request({ ...options, method: 'PATCH' }),
     post: (options) => request({ ...options, method: 'POST' }),
     put: (options) => request({ ...options, method: 'PUT' }),
     request,
     setConfig,
-  } as Client
+    trace: (options) => request({ ...options, method: 'TRACE' }),
+  }
 }

--- a/src/client/client/index.ts
+++ b/src/client/client/index.ts
@@ -16,6 +16,7 @@ export type {
   OptionsLegacyParser,
   RequestOptions,
   RequestResult,
+  ResponseStyle,
   TDataShape,
 } from './types'
-export { createConfig } from './utils'
+export { createConfig, mergeHeaders } from './utils'

--- a/src/client/client/types.ts
+++ b/src/client/client/types.ts
@@ -1,47 +1,52 @@
-import type {
-  AxiosError,
-  AxiosInstance,
-  AxiosResponse,
-  AxiosStatic,
-  CreateAxiosDefaults,
-} from 'axios'
-
 import type { Auth } from '../core/auth'
 import type { Client as CoreClient, Config as CoreConfig } from '../core/types'
+import type { Middleware } from './utils'
+
+export type ResponseStyle = 'data' | 'fields'
 
 export interface Config<T extends ClientOptions = ClientOptions>
-  extends
-    Omit<CreateAxiosDefaults, 'auth' | 'baseURL' | 'headers' | 'method'>,
+  extends Omit<RequestInit, 'body' | 'headers' | 'method'>,
     CoreConfig {
-  /**
-   * Axios implementation. You can use this option to provide a custom
-   * Axios instance.
-   *
-   * @default axios
-   */
-  axios?: AxiosStatic
   /**
    * Base URL for all requests made by this client.
    */
-  baseURL?: T['baseURL']
+  baseUrl?: T['baseUrl']
   /**
-   * An object containing any HTTP headers that you want to pre-populate your
-   * `Headers` object with.
+   * Fetch API implementation. You can use this option to provide a custom
+   * fetch instance.
    *
-   * {@link https://developer.mozilla.org/docs/Web/API/Headers/Headers#init See more}
+   * @default globalThis.fetch
    */
-  headers?:
-    | CreateAxiosDefaults['headers']
-    | Record<
-        string,
-        | string
-        | number
-        | boolean
-        | Array<string | number | boolean>
-        | null
-        | undefined
-        | unknown
-      >
+  fetch?: (request: Request) => ReturnType<typeof fetch>
+  /**
+   * Please don't use the Fetch client for Next.js applications. The `next`
+   * options won't have any effect.
+   *
+   * Install {@link https://www.npmjs.com/package/@hey-api/client-next `@hey-api/client-next`} instead.
+   */
+  next?: never
+  /**
+   * Return the response data parsed in a specified format. By default, `auto`
+   * will infer the appropriate method from the `Content-Type` response header.
+   * You can override this behavior with any of the {@link Body} methods.
+   * Select `stream` if you don't want to parse response data at all.
+   *
+   * @default 'auto'
+   */
+  parseAs?:
+    | 'arrayBuffer'
+    | 'auto'
+    | 'blob'
+    | 'formData'
+    | 'json'
+    | 'stream'
+    | 'text'
+  /**
+   * Should we return only data or multiple fields (data, error, response, etc.)?
+   *
+   * @default 'fields'
+   */
+  responseStyle?: ResponseStyle
   /**
    * Throw an error instead of returning it in the response?
    *
@@ -51,11 +56,13 @@ export interface Config<T extends ClientOptions = ClientOptions>
 }
 
 export interface RequestOptions<
+  TResponseStyle extends ResponseStyle = 'fields',
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends Config<{
-  throwOnError: ThrowOnError
-}> {
+    responseStyle: TResponseStyle
+    throwOnError: ThrowOnError
+  }> {
   /**
    * Any body that you want to add to your request.
    *
@@ -75,28 +82,50 @@ export type RequestResult<
   TData = unknown,
   TError = unknown,
   ThrowOnError extends boolean = boolean,
+  TResponseStyle extends ResponseStyle = 'fields',
 > = ThrowOnError extends true
   ? Promise<
-      AxiosResponse<
-        TData extends Record<string, unknown> ? TData[keyof TData] : TData
-      >
+      TResponseStyle extends 'data'
+        ? TData extends Record<string, unknown>
+          ? TData[keyof TData]
+          : TData
+        : {
+            data: TData extends Record<string, unknown>
+              ? TData[keyof TData]
+              : TData
+            request: Request
+            response: Response
+          }
     >
   : Promise<
-      | (AxiosResponse<
-          TData extends Record<string, unknown> ? TData[keyof TData] : TData
-        > & { error: undefined })
-      | (AxiosError<
-          TError extends Record<string, unknown> ? TError[keyof TError] : TError
-        > & {
-          data: undefined
-          error: TError extends Record<string, unknown>
-            ? TError[keyof TError]
-            : TError
-        })
+      TResponseStyle extends 'data'
+        ?
+            | (TData extends Record<string, unknown>
+                ? TData[keyof TData]
+                : TData)
+            | undefined
+        : (
+            | {
+                data: TData extends Record<string, unknown>
+                  ? TData[keyof TData]
+                  : TData
+                error: undefined
+              }
+            | {
+                data: undefined
+                error: TError extends Record<string, unknown>
+                  ? TError[keyof TError]
+                  : TError
+              }
+          ) & {
+            request: Request
+            response: Response
+          }
     >
 
 export interface ClientOptions {
-  baseURL?: string
+  baseUrl?: string
+  responseStyle?: ResponseStyle
   throwOnError?: boolean
 }
 
@@ -104,18 +133,20 @@ type MethodFn = <
   TData = unknown,
   TError = unknown,
   ThrowOnError extends boolean = false,
+  TResponseStyle extends ResponseStyle = 'fields',
 >(
-  options: Omit<RequestOptions<ThrowOnError>, 'method'>,
-) => RequestResult<TData, TError, ThrowOnError>
+  options: Omit<RequestOptions<TResponseStyle, ThrowOnError>, 'method'>,
+) => RequestResult<TData, TError, ThrowOnError, TResponseStyle>
 
 type RequestFn = <
   TData = unknown,
   TError = unknown,
   ThrowOnError extends boolean = false,
+  TResponseStyle extends ResponseStyle = 'fields',
 >(
-  options: Omit<RequestOptions<ThrowOnError>, 'method'> &
-    Pick<Required<RequestOptions<ThrowOnError>>, 'method'>,
-) => RequestResult<TData, TError, ThrowOnError>
+  options: Omit<RequestOptions<TResponseStyle, ThrowOnError>, 'method'> &
+    Pick<Required<RequestOptions<TResponseStyle, ThrowOnError>>, 'method'>,
+) => RequestResult<TData, TError, ThrowOnError, TResponseStyle>
 
 type BuildUrlFn = <
   TData extends {
@@ -125,11 +156,11 @@ type BuildUrlFn = <
     url: string
   },
 >(
-  options: Pick<TData, 'url'> & Omit<Options<TData>, 'axios'>,
+  options: Pick<TData, 'url'> & Options<TData>,
 ) => string
 
 export type Client = CoreClient<RequestFn, Config, MethodFn, BuildUrlFn> & {
-  instance: AxiosInstance
+  interceptors: Middleware<Request, Response, unknown, RequestOptions>
 }
 
 /**
@@ -157,20 +188,32 @@ type OmitKeys<T, K> = Pick<T, Exclude<keyof T, K>>
 export type Options<
   TData extends TDataShape = TDataShape,
   ThrowOnError extends boolean = boolean,
-> = OmitKeys<RequestOptions<ThrowOnError>, 'body' | 'path' | 'query' | 'url'> &
+  TResponseStyle extends ResponseStyle = 'fields',
+> = OmitKeys<
+  RequestOptions<TResponseStyle, ThrowOnError>,
+  'body' | 'path' | 'query' | 'url'
+> &
   Omit<TData, 'url'>
 
 export type OptionsLegacyParser<
   TData = unknown,
   ThrowOnError extends boolean = boolean,
+  TResponseStyle extends ResponseStyle = 'fields',
 > = TData extends { body?: any }
   ? TData extends { headers?: any }
-    ? OmitKeys<RequestOptions<ThrowOnError>, 'body' | 'headers' | 'url'> & TData
-    : OmitKeys<RequestOptions<ThrowOnError>, 'body' | 'url'> &
+    ? OmitKeys<
+        RequestOptions<TResponseStyle, ThrowOnError>,
+        'body' | 'headers' | 'url'
+      > &
+        TData
+    : OmitKeys<RequestOptions<TResponseStyle, ThrowOnError>, 'body' | 'url'> &
         TData &
-        Pick<RequestOptions<ThrowOnError>, 'headers'>
+        Pick<RequestOptions<TResponseStyle, ThrowOnError>, 'headers'>
   : TData extends { headers?: any }
-    ? OmitKeys<RequestOptions<ThrowOnError>, 'headers' | 'url'> &
+    ? OmitKeys<
+        RequestOptions<TResponseStyle, ThrowOnError>,
+        'headers' | 'url'
+      > &
         TData &
-        Pick<RequestOptions<ThrowOnError>, 'body'>
-    : OmitKeys<RequestOptions<ThrowOnError>, 'url'> & TData
+        Pick<RequestOptions<TResponseStyle, ThrowOnError>, 'body'>
+    : OmitKeys<RequestOptions<TResponseStyle, ThrowOnError>, 'url'> & TData

--- a/src/client/client/utils.ts
+++ b/src/client/client/utils.ts
@@ -1,4 +1,5 @@
 import { getAuthToken } from '../core/auth'
+import { jsonBodySerializer } from '../core/bodySerializer'
 import {
   serializeArrayParam,
   serializeObjectParam,
@@ -8,7 +9,6 @@ import type {
   QuerySerializer,
   QuerySerializerOptions,
 } from '../core/bodySerializer'
-import type { ArraySeparatorStyle } from '../core/pathSerializer'
 import type { Client, ClientOptions, Config, RequestOptions } from './types'
 
 interface PathSerializer {
@@ -17,6 +17,10 @@ interface PathSerializer {
 }
 
 const PATH_PARAM_RE = /\{[^{}]+\}/g
+
+type ArrayStyle = 'form' | 'spaceDelimited' | 'pipeDelimited'
+type MatrixStyle = 'label' | 'matrix' | 'simple'
+type ArraySeparatorStyle = ArrayStyle | MatrixStyle
 
 const defaultPathSerializer = ({ path, url: _url }: PathSerializer) => {
   let url = _url
@@ -138,12 +142,56 @@ export const createQuerySerializer = <T = unknown>({
   return querySerializer
 }
 
+/**
+ * Infers parseAs value from provided Content-Type header.
+ */
+export const getParseAs = (
+  contentType: string | null,
+): Exclude<Config['parseAs'], 'auto'> => {
+  if (!contentType) {
+    // If no Content-Type header is provided, the best we can do is return the raw response body,
+    // which is effectively the same as the 'stream' option.
+    return 'stream'
+  }
+
+  const cleanContent = contentType.split(';')[0]?.trim()
+
+  if (!cleanContent) {
+    return
+  }
+
+  if (
+    cleanContent.startsWith('application/json') ||
+    cleanContent.endsWith('+json')
+  ) {
+    return 'json'
+  }
+
+  if (cleanContent === 'multipart/form-data') {
+    return 'formData'
+  }
+
+  if (
+    ['application/', 'audio/', 'image/', 'video/'].some((type) =>
+      cleanContent.startsWith(type),
+    )
+  ) {
+    return 'blob'
+  }
+
+  if (cleanContent.startsWith('text/')) {
+    return 'text'
+  }
+
+  return
+}
+
 export const setAuthParams = async ({
   security,
   ...options
 }: Pick<Required<RequestOptions>, 'security'> &
   Pick<RequestOptions, 'auth' | 'query'> & {
-    headers: Record<any, unknown>
+    headers: Headers
   }) => {
   for (const auth of security) {
     const token = await getAuthToken(auth, options.auth)
@@ -161,18 +209,12 @@ export const setAuthParams = async ({
         }
         options.query[name] = token
         break
-      case 'cookie': {
-        const value = `${name}=${token}`
-        if ('Cookie' in options.headers && options.headers['Cookie']) {
-          options.headers['Cookie'] = `${options.headers['Cookie']}; ${value}`
-        } else {
-          options.headers['Cookie'] = value
-        }
+      case 'cookie':
+        options.headers.append('Cookie', `${name}=${token}`)
         break
-      }
       case 'header':
       default:
-        options.headers[name] = token
+        options.headers.set(name, token)
         break
     }
 
@@ -182,9 +224,9 @@ export const setAuthParams = async ({
 
 export const buildUrl: Client['buildUrl'] = (options) => {
   const url = getUrl({
+    baseUrl: options.baseUrl as string,
     path: options.path,
-    // let `paramsSerializer()` handle query params if it exists
-    query: !options.paramsSerializer ? options.query : undefined,
+    query: options.query,
     querySerializer:
       typeof options.querySerializer === 'function'
         ? options.querySerializer
@@ -195,18 +237,20 @@ export const buildUrl: Client['buildUrl'] = (options) => {
 }
 
 export const getUrl = ({
+  baseUrl,
   path,
   query,
   querySerializer,
   url: _url,
 }: {
+  baseUrl?: string
   path?: Record<string, unknown>
   query?: Record<string, unknown>
   querySerializer: QuerySerializer
   url: string
 }) => {
   const pathUrl = _url.startsWith('/') ? _url : `/${_url}`
-  let url = pathUrl
+  let url = (baseUrl ?? '') + pathUrl
   if (path) {
     url = defaultPathSerializer({ path, url })
   }
@@ -222,65 +266,152 @@ export const getUrl = ({
 
 export const mergeConfigs = (a: Config, b: Config): Config => {
   const config = { ...a, ...b }
+  if (config.baseUrl?.endsWith('/')) {
+    config.baseUrl = config.baseUrl.substring(0, config.baseUrl.length - 1)
+  }
   config.headers = mergeHeaders(a.headers, b.headers)
   return config
 }
 
-/**
- * Special Axios headers keywords allowing to set headers by request method.
- */
-export const axiosHeadersKeywords = [
-  'common',
-  'delete',
-  'get',
-  'head',
-  'patch',
-  'post',
-  'put',
-] as const
-
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
-): Record<any, unknown> => {
-  const mergedHeaders: Record<any, unknown> = {}
+): Headers => {
+  const mergedHeaders = new Headers()
   for (const header of headers) {
     if (!header || typeof header !== 'object') {
       continue
     }
 
-    const iterator = Object.entries(header)
+    const iterator =
+      header instanceof Headers ? header.entries() : Object.entries(header)
 
     for (const [key, value] of iterator) {
-      if (
-        axiosHeadersKeywords.includes(
-          key as (typeof axiosHeadersKeywords)[number],
-        ) &&
-        typeof value === 'object'
-      ) {
-        mergedHeaders[key] = {
-          ...(mergedHeaders[key] as Record<any, unknown>),
-          ...value,
-        }
-      } else if (value === null) {
-        delete mergedHeaders[key]
+      if (value === null) {
+        mergedHeaders.delete(key)
       } else if (Array.isArray(value)) {
         for (const v of value) {
-          // @ts-expect-error
-          mergedHeaders[key] = [...(mergedHeaders[key] ?? []), v as string]
+          mergedHeaders.append(key, v as string)
         }
       } else if (value !== undefined) {
         // assume object headers are meant to be JSON stringified, i.e. their
         // content value in OpenAPI specification is 'application/json'
-        mergedHeaders[key] =
-          typeof value === 'object' ? JSON.stringify(value) : (value as string)
+        mergedHeaders.set(
+          key,
+          typeof value === 'object' ? JSON.stringify(value) : (value as string),
+        )
       }
     }
   }
   return mergedHeaders
 }
 
+type ErrInterceptor<Err, Res, Req, Options> = (
+  error: Err,
+  response: Res,
+  request: Req,
+  options: Options,
+) => Err | Promise<Err>
+
+type ReqInterceptor<Req, Options> = (
+  request: Req,
+  options: Options,
+) => Req | Promise<Req>
+
+type ResInterceptor<Res, Req, Options> = (
+  response: Res,
+  request: Req,
+  options: Options,
+) => Res | Promise<Res>
+
+class Interceptors<Interceptor> {
+  _fns: Array<Interceptor | null>
+
+  constructor() {
+    this._fns = []
+  }
+
+  clear() {
+    this._fns = []
+  }
+
+  getInterceptorIndex(id: number | Interceptor): number {
+    if (typeof id === 'number') {
+      return this._fns[id] ? id : -1
+    } else {
+      return this._fns.indexOf(id)
+    }
+  }
+  exists(id: number | Interceptor) {
+    const index = this.getInterceptorIndex(id)
+    return !!this._fns[index]
+  }
+
+  eject(id: number | Interceptor) {
+    const index = this.getInterceptorIndex(id)
+    if (this._fns[index]) {
+      this._fns[index] = null
+    }
+  }
+
+  update(id: number | Interceptor, fn: Interceptor) {
+    const index = this.getInterceptorIndex(id)
+    if (this._fns[index]) {
+      this._fns[index] = fn
+      return id
+    } else {
+      return false
+    }
+  }
+
+  use(fn: Interceptor) {
+    this._fns = [...this._fns, fn]
+    return this._fns.length - 1
+  }
+}
+
+// `createInterceptors()` response, meant for external use as it does not
+// expose internals
+export interface Middleware<Req, Res, Err, Options> {
+  error: Pick<
+    Interceptors<ErrInterceptor<Err, Res, Req, Options>>,
+    'eject' | 'use'
+  >
+  request: Pick<Interceptors<ReqInterceptor<Req, Options>>, 'eject' | 'use'>
+  response: Pick<
+    Interceptors<ResInterceptor<Res, Req, Options>>,
+    'eject' | 'use'
+  >
+}
+
+// do not add `Middleware` as return type so we can use _fns internally
+export const createInterceptors = <Req, Res, Err, Options>() => ({
+  error: new Interceptors<ErrInterceptor<Err, Res, Req, Options>>(),
+  request: new Interceptors<ReqInterceptor<Req, Options>>(),
+  response: new Interceptors<ResInterceptor<Res, Req, Options>>(),
+})
+
+const defaultQuerySerializer = createQuerySerializer({
+  allowReserved: false,
+  array: {
+    explode: true,
+    style: 'form',
+  },
+  object: {
+    explode: true,
+    style: 'deepObject',
+  },
+})
+
+const defaultHeaders = {
+  'Content-Type': 'application/json',
+}
+
 export const createConfig = <T extends ClientOptions = ClientOptions>(
   override: Config<Omit<ClientOptions, keyof T> & T> = {},
 ): Config<Omit<ClientOptions, keyof T> & T> => ({
+  ...jsonBodySerializer,
+  headers: defaultHeaders,
+  parseAs: 'auto',
+  querySerializer: defaultQuerySerializer,
   ...override,
 })

--- a/src/client/core/pathSerializer.ts
+++ b/src/client/core/pathSerializer.ts
@@ -1,5 +1,6 @@
 interface SerializeOptions<T>
-  extends SerializePrimitiveOptions, SerializerOptions<T> {}
+  extends SerializePrimitiveOptions,
+    SerializerOptions<T> {}
 
 interface SerializePrimitiveOptions {
   allowReserved?: boolean

--- a/src/client/sdk.gen.ts
+++ b/src/client/sdk.gen.ts
@@ -34,6 +34,9 @@ import type {
   ChangePasswordData,
   ChangePasswordErrors,
   ChangePasswordResponses,
+  ChatData,
+  ChatErrors,
+  ChatResponses,
   ClearSamplesForRunData,
   ClearSamplesForRunErrors,
   ClearSamplesForRunResponses,
@@ -372,7 +375,6 @@ export const root = <ThrowOnError extends boolean = false>(
     unknown,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/',
     ...options,
   })
@@ -389,7 +391,6 @@ export const healthCheck = <ThrowOnError extends boolean = false>(
     unknown,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/health',
     ...options,
   })
@@ -421,7 +422,6 @@ export const register = <ThrowOnError extends boolean = false>(
     RegisterErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/auth/register',
     ...options,
     headers: {
@@ -459,7 +459,6 @@ export const login = <ThrowOnError extends boolean = false>(
     ThrowOnError
   >({
     ...urlSearchParamsBodySerializer,
-    responseType: 'json',
     url: '/api/v1/auth/login',
     ...options,
     headers: {
@@ -494,7 +493,6 @@ export const refreshToken = <ThrowOnError extends boolean = false>(
     RefreshTokenErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/auth/refresh',
     ...options,
     headers: {
@@ -526,7 +524,6 @@ export const logout = <ThrowOnError extends boolean = false>(
     LogoutErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/auth/logout',
     ...options,
     headers: {
@@ -560,7 +557,6 @@ export const getCurrentUserInfo = <ThrowOnError extends boolean = false>(
     unknown,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -594,7 +590,6 @@ export const requestPasswordReset = <ThrowOnError extends boolean = false>(
     RequestPasswordResetErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/auth/password-reset/request',
     ...options,
     headers: {
@@ -628,7 +623,6 @@ export const confirmPasswordReset = <ThrowOnError extends boolean = false>(
     ConfirmPasswordResetErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/auth/password-reset/confirm',
     ...options,
     headers: {
@@ -665,7 +659,6 @@ export const changePassword = <ThrowOnError extends boolean = false>(
     ChangePasswordErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -705,7 +698,6 @@ export const verifyEmail = <ThrowOnError extends boolean = false>(
     VerifyEmailErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/auth/verify-email',
     ...options,
     headers: {
@@ -740,7 +732,6 @@ export const resendVerification = <ThrowOnError extends boolean = false>(
     ResendVerificationErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/auth/resend-verification',
     ...options,
     headers: {
@@ -762,7 +753,6 @@ export const listApiKeys = <ThrowOnError extends boolean = false>(
     ListApiKeysErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -786,7 +776,6 @@ export const createApiKey = <ThrowOnError extends boolean = false>(
     CreateApiKeyErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -837,7 +826,6 @@ export const revokeApiKey = <ThrowOnError extends boolean = false>(
     RevokeApiKeyErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -866,7 +854,6 @@ export const getAvailableOauthProviders = <
     unknown,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/auth/oauth/providers',
     ...options,
   })
@@ -897,7 +884,6 @@ export const oauthAuthorize = <ThrowOnError extends boolean = false>(
     OauthAuthorizeErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/auth/oauth/{provider}/authorize',
     ...options,
   })
@@ -932,7 +918,6 @@ export const oauthCallback = <ThrowOnError extends boolean = false>(
     OauthCallbackErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/auth/oauth/{provider}/callback',
     ...options,
   })
@@ -966,7 +951,6 @@ export const linkOauthProvider = <ThrowOnError extends boolean = false>(
     LinkOauthProviderErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -1010,7 +994,6 @@ export const unlinkOauthProvider = <ThrowOnError extends boolean = false>(
     UnlinkOauthProviderErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -1037,7 +1020,6 @@ export const getAllConfigs = <ThrowOnError extends boolean = false>(
     unknown,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/actions/configs',
     ...options,
   })
@@ -1070,7 +1052,6 @@ export const validateActionConfig = <ThrowOnError extends boolean = false>(
     ValidateActionConfigErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/actions/config/validate',
     ...options,
   })
@@ -1092,7 +1073,6 @@ export const getActionOptions = <ThrowOnError extends boolean = false>(
     unknown,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/actions/options',
     ...options,
   })
@@ -1113,7 +1093,6 @@ export const getActionPlatforms = <ThrowOnError extends boolean = false>(
     unknown,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/actions/platforms',
     ...options,
   })
@@ -1138,9 +1117,35 @@ export const getActionTypes = <ThrowOnError extends boolean = false>(
     GetActionTypesErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/actions/types',
     ...options,
+  })
+}
+
+/**
+ * Chat
+ * Stream an assistant reply for the given message history.
+ */
+export const chat = <ThrowOnError extends boolean = false>(
+  options: Options<ChatData, ThrowOnError>,
+) => {
+  return (options.client ?? _heyApiClient).post<
+    ChatResponses,
+    ChatErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+    ],
+    url: '/api/v1/chat',
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
   })
 }
 
@@ -1162,7 +1167,6 @@ export const listFiles = <ThrowOnError extends boolean = false>(
     ListFilesErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/files',
     ...options,
   })
@@ -1197,7 +1201,6 @@ export const createFile = <ThrowOnError extends boolean = false>(
     CreateFileErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/files',
     ...options,
     headers: {
@@ -1239,7 +1242,6 @@ export const uploadFile = <ThrowOnError extends boolean = false>(
     ThrowOnError
   >({
     ...formDataBodySerializer,
-    responseType: 'json',
     url: '/api/v1/files/upload',
     ...options,
     headers: {
@@ -1264,7 +1266,6 @@ export const browseS3 = <ThrowOnError extends boolean = false>(
     BrowseS3Errors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/files/list',
     ...options,
   })
@@ -1286,7 +1287,6 @@ export const downloadFile = <ThrowOnError extends boolean = false>(
     DownloadFileErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/files/download',
     ...options,
   })
@@ -1336,7 +1336,6 @@ export const getFile = <ThrowOnError extends boolean = false>(
     GetFileErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/files/{file_id}',
     ...options,
   })
@@ -1362,7 +1361,6 @@ export const updateFile = <ThrowOnError extends boolean = false>(
     UpdateFileErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -1392,7 +1390,6 @@ export const getFileVersions = <ThrowOnError extends boolean = false>(
     GetFileVersionsErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/files/{file_id}/versions',
     ...options,
   })
@@ -1422,7 +1419,6 @@ export const getJobs = <ThrowOnError extends boolean = false>(
     GetJobsErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/jobs',
     ...options,
   })
@@ -1451,7 +1447,6 @@ export const submitJob = <ThrowOnError extends boolean = false>(
     SubmitJobErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/jobs',
     ...options,
     headers: {
@@ -1480,7 +1475,6 @@ export const getJob = <ThrowOnError extends boolean = false>(
     GetJobErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/jobs/{job_id}',
     ...options,
   })
@@ -1506,7 +1500,6 @@ export const updateJob = <ThrowOnError extends boolean = false>(
     UpdateJobErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/jobs/{job_id}',
     ...options,
     headers: {
@@ -1535,7 +1528,6 @@ export const getJobLog = <ThrowOnError extends boolean = false>(
     GetJobLogErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/jobs/{job_id}/log',
     ...options,
   })
@@ -1570,7 +1562,6 @@ export const getJobLogPaginated = <ThrowOnError extends boolean = false>(
     GetJobLogPaginatedErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/jobs/{job_id}/log/paginated',
     ...options,
   })
@@ -1600,7 +1591,6 @@ export const getLatestManifest = <ThrowOnError extends boolean = false>(
     GetLatestManifestErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/manifest',
     ...options,
   })
@@ -1627,7 +1617,6 @@ export const uploadManifest = <ThrowOnError extends boolean = false>(
     ThrowOnError
   >({
     ...formDataBodySerializer,
-    responseType: 'json',
     url: '/api/v1/manifest',
     ...options,
     headers: {
@@ -1663,7 +1652,6 @@ export const validateManifest = <ThrowOnError extends boolean = false>(
     ValidateManifestErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/manifest/validate',
     ...options,
   })
@@ -1681,7 +1669,6 @@ export const getProjects = <ThrowOnError extends boolean = false>(
     GetProjectsErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/projects',
     ...options,
   })
@@ -1699,7 +1686,6 @@ export const createProject = <ThrowOnError extends boolean = false>(
     CreateProjectErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -1731,7 +1717,6 @@ export const getProjectAttributes = <ThrowOnError extends boolean = false>(
     unknown,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/projects/attributes',
     ...options,
   })
@@ -1749,7 +1734,6 @@ export const searchProjects = <ThrowOnError extends boolean = false>(
     SearchProjectsErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/projects/search',
     ...options,
   })
@@ -1767,7 +1751,6 @@ export const reindexProjects = <ThrowOnError extends boolean = false>(
     unknown,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/projects/search',
     ...options,
   })
@@ -1786,7 +1769,6 @@ export const getProjectByProjectId = <ThrowOnError extends boolean = false>(
     GetProjectByProjectIdErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/projects/{project_id}',
     ...options,
   })
@@ -1809,7 +1791,6 @@ export const patchProject = <ThrowOnError extends boolean = false>(
     PatchProjectErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/projects/{project_id}',
     ...options,
     headers: {
@@ -1835,7 +1816,6 @@ export const updateProject = <ThrowOnError extends boolean = false>(
     UpdateProjectErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/projects/{project_id}',
     ...options,
     headers: {
@@ -1864,7 +1844,6 @@ export const getProjectSamples = <ThrowOnError extends boolean = false>(
     GetProjectSamplesErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/projects/{project_id}/samples',
     ...options,
   })
@@ -1885,7 +1864,6 @@ export const addSampleToProject = <ThrowOnError extends boolean = false>(
     AddSampleToProjectErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -1922,7 +1900,6 @@ export const uploadSamplesFile = <ThrowOnError extends boolean = false>(
     ThrowOnError
   >({
     ...formDataBodySerializer,
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -1954,7 +1931,6 @@ export const bulkCreateSamples = <ThrowOnError extends boolean = false>(
     BulkCreateSamplesErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -2010,7 +1986,6 @@ export const updateSampleInProject = <ThrowOnError extends boolean = false>(
     UpdateSampleInProjectErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/projects/{project_id}/samples/{sample_id}',
     ...options,
     headers: {
@@ -2052,7 +2027,6 @@ export const submitPipelineJob = <ThrowOnError extends boolean = false>(
     SubmitPipelineJobErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -2083,7 +2057,6 @@ export const ingestVendorData = <ThrowOnError extends boolean = false>(
     IngestVendorDataErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -2159,7 +2132,6 @@ export const createQcrecord = <ThrowOnError extends boolean = false>(
     CreateQcrecordErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -2202,7 +2174,6 @@ export const searchQcrecordsGet = <ThrowOnError extends boolean = false>(
     SearchQcrecordsGetErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/qcmetrics/search',
     ...options,
   })
@@ -2249,7 +2220,6 @@ export const searchQcrecordsPost = <ThrowOnError extends boolean = false>(
     SearchQcrecordsPostErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/qcmetrics/search',
     ...options,
     headers: {
@@ -2279,7 +2249,6 @@ export const deleteQcrecord = <ThrowOnError extends boolean = false>(
     DeleteQcrecordErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/qcmetrics/{qcrecord_id}',
     ...options,
   })
@@ -2299,7 +2268,6 @@ export const getQcrecord = <ThrowOnError extends boolean = false>(
     GetQcrecordErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/qcmetrics/{qcrecord_id}',
     ...options,
   })
@@ -2317,7 +2285,6 @@ export const getRuns = <ThrowOnError extends boolean = false>(
     GetRunsErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/runs',
     ...options,
   })
@@ -2335,7 +2302,6 @@ export const addRun = <ThrowOnError extends boolean = false>(
     AddRunErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/runs',
     ...options,
     headers: {
@@ -2357,7 +2323,6 @@ export const searchRuns = <ThrowOnError extends boolean = false>(
     SearchRunsErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/runs/search',
     ...options,
   })
@@ -2375,7 +2340,6 @@ export const reindexRuns = <ThrowOnError extends boolean = false>(
     unknown,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/runs/search',
     ...options,
   })
@@ -2395,7 +2359,6 @@ export const listDemultiplexWorkflows = <ThrowOnError extends boolean = false>(
     unknown,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/runs/demultiplex',
     ...options,
   })
@@ -2422,7 +2385,6 @@ export const submitDemultiplexWorkflowJob = <
     SubmitDemultiplexWorkflowJobErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -2459,7 +2421,6 @@ export const getDemultiplexWorkflowConfig = <
     GetDemultiplexWorkflowConfigErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/runs/demultiplex/{workflow_id}',
     ...options,
   })
@@ -2477,7 +2438,6 @@ export const getRun = <ThrowOnError extends boolean = false>(
     GetRunErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/runs/{run_id}',
     ...options,
   })
@@ -2496,7 +2456,6 @@ export const updateRun = <ThrowOnError extends boolean = false>(
     UpdateRunErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/runs/{run_id}',
     ...options,
     headers: {
@@ -2518,7 +2477,6 @@ export const getRunSamplesheet = <ThrowOnError extends boolean = false>(
     GetRunSamplesheetErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/runs/{run_id}/samplesheet',
     ...options,
   })
@@ -2537,7 +2495,6 @@ export const postRunSamplesheet = <ThrowOnError extends boolean = false>(
     ThrowOnError
   >({
     ...formDataBodySerializer,
-    responseType: 'json',
     url: '/api/v1/runs/{run_id}/samplesheet',
     ...options,
     headers: {
@@ -2559,7 +2516,6 @@ export const getRunMetrics = <ThrowOnError extends boolean = false>(
     GetRunMetricsErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/runs/{run_id}/metrics',
     ...options,
   })
@@ -2582,7 +2538,6 @@ export const clearSamplesForRun = <ThrowOnError extends boolean = false>(
     ClearSamplesForRunErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -2606,7 +2561,6 @@ export const getSamplesForRun = <ThrowOnError extends boolean = false>(
     GetSamplesForRunErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/runs/{run_id}/samples',
     ...options,
   })
@@ -2624,7 +2578,6 @@ export const associateSampleWithRun = <ThrowOnError extends boolean = false>(
     AssociateSampleWithRunErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -2667,7 +2620,7 @@ export const removeSampleFromRun = <ThrowOnError extends boolean = false>(
  * Supported filter keys:
  * - ``projectid``: exact match on project ID
  * - ``samplename``: exact match on sample name
- * - ``created_on``: date prefix match (YYYY-MM-DD) on created_at
+ * - ``created_at``: date prefix match (YYYY-MM-DD) on created_at
  * - Any other key: matched against sample attributes (case-insensitive key)
  *
  * Multiple filters are AND'd together.
@@ -2680,7 +2633,6 @@ export const searchSamplesGet = <ThrowOnError extends boolean = false>(
     SearchSamplesGetErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/samples/search',
     ...options,
   })
@@ -2706,7 +2658,7 @@ export const searchSamplesGet = <ThrowOnError extends boolean = false>(
  * ``filter_on`` supports:
  * - ``projectid`` (str or list)
  * - ``samplename`` (str or list)
- * - ``created_on`` (str, date prefix match)
+ * - ``created_at`` (str, date prefix match)
  * - ``tags`` (dict of key/value pairs, matched case-insensitively)
  * - Any other key is matched against sample attributes
  *
@@ -2720,7 +2672,6 @@ export const searchSamplesPost = <ThrowOnError extends boolean = false>(
     SearchSamplesPostErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/samples/search',
     ...options,
     headers: {
@@ -2742,7 +2693,6 @@ export const reindexSamples = <ThrowOnError extends boolean = false>(
     unknown,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/samples/reindex',
     ...options,
   })
@@ -2760,7 +2710,6 @@ export const search = <ThrowOnError extends boolean = false>(
     SearchErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/search',
     ...options,
   })
@@ -2779,7 +2728,6 @@ export const getSettingsByTag = <ThrowOnError extends boolean = false>(
     GetSettingsByTagErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/settings',
     ...options,
   })
@@ -2797,7 +2745,6 @@ export const getSetting = <ThrowOnError extends boolean = false>(
     GetSettingErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/settings/{key}',
     ...options,
   })
@@ -2816,7 +2763,6 @@ export const updateSetting = <ThrowOnError extends boolean = false>(
     UpdateSettingErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/settings/{key}',
     ...options,
     headers: {
@@ -2838,7 +2784,6 @@ export const getVendors = <ThrowOnError extends boolean = false>(
     GetVendorsErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/vendors',
     ...options,
   })
@@ -2856,7 +2801,6 @@ export const addVendor = <ThrowOnError extends boolean = false>(
     AddVendorErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/vendors',
     ...options,
     headers: {
@@ -2895,7 +2839,6 @@ export const getVendor = <ThrowOnError extends boolean = false>(
     GetVendorErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/vendors/{vendor_id}',
     ...options,
   })
@@ -2913,7 +2856,6 @@ export const updateVendor = <ThrowOnError extends boolean = false>(
     UpdateVendorErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/vendors/{vendor_id}',
     ...options,
     headers: {
@@ -2935,7 +2877,6 @@ export const getWorkflows = <ThrowOnError extends boolean = false>(
     GetWorkflowsErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/workflows',
     ...options,
   })
@@ -2953,7 +2894,6 @@ export const createWorkflow = <ThrowOnError extends boolean = false>(
     CreateWorkflowErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -2981,7 +2921,6 @@ export const getWorkflowById = <ThrowOnError extends boolean = false>(
     GetWorkflowByIdErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/workflows/{workflow_id}',
     ...options,
   })
@@ -2999,7 +2938,6 @@ export const getWorkflowVersions = <ThrowOnError extends boolean = false>(
     GetWorkflowVersionsErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/workflows/{workflow_id}/versions',
     ...options,
   })
@@ -3017,7 +2955,6 @@ export const createWorkflowVersion = <ThrowOnError extends boolean = false>(
     CreateWorkflowVersionErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -3045,7 +2982,6 @@ export const getWorkflowVersion = <ThrowOnError extends boolean = false>(
     GetWorkflowVersionErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/workflows/{workflow_id}/versions/{version_num}',
     ...options,
   })
@@ -3082,7 +3018,6 @@ export const setWorkflowVersionAlias = <ThrowOnError extends boolean = false>(
     SetWorkflowVersionAliasErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -3110,7 +3045,6 @@ export const getWorkflowVersionAliases = <ThrowOnError extends boolean = false>(
     GetWorkflowVersionAliasesErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/workflows/{workflow_id}/aliases',
     ...options,
   })
@@ -3138,7 +3072,6 @@ export const getWorkflowDeploymentsForWorkflow = <
     GetWorkflowDeploymentsForWorkflowErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/workflows/{workflow_id}/deployments',
     ...options,
   })
@@ -3156,7 +3089,6 @@ export const getWorkflowDeployments = <ThrowOnError extends boolean = false>(
     GetWorkflowDeploymentsErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/workflows/{workflow_id}/versions/{version_num}/deployments',
     ...options,
   })
@@ -3174,7 +3106,6 @@ export const createWorkflowDeployment = <ThrowOnError extends boolean = false>(
     CreateWorkflowDeploymentErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -3219,7 +3150,6 @@ export const getPipelines = <ThrowOnError extends boolean = false>(
     GetPipelinesErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/pipelines',
     ...options,
   })
@@ -3237,7 +3167,6 @@ export const createPipeline = <ThrowOnError extends boolean = false>(
     CreatePipelineErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -3265,7 +3194,6 @@ export const getPipelineById = <ThrowOnError extends boolean = false>(
     GetPipelineByIdErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/pipelines/{pipeline_id}',
     ...options,
   })
@@ -3283,7 +3211,6 @@ export const addWorkflowToPipeline = <ThrowOnError extends boolean = false>(
     AddWorkflowToPipelineErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',
@@ -3326,7 +3253,6 @@ export const getPlatforms = <ThrowOnError extends boolean = false>(
     unknown,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/platforms',
     ...options,
   })
@@ -3344,7 +3270,6 @@ export const createPlatform = <ThrowOnError extends boolean = false>(
     CreatePlatformErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/platforms',
     ...options,
     headers: {
@@ -3366,7 +3291,6 @@ export const getPlatformByName = <ThrowOnError extends boolean = false>(
     GetPlatformByNameErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     url: '/api/v1/platforms/{name}',
     ...options,
   })
@@ -3389,7 +3313,6 @@ export const searchUsers = <ThrowOnError extends boolean = false>(
     SearchUsersErrors,
     ThrowOnError
   >({
-    responseType: 'json',
     security: [
       {
         scheme: 'bearer',

--- a/src/client/types.gen.ts
+++ b/src/client/types.gen.ts
@@ -215,7 +215,6 @@ export type ActionSubmitRequest = {
 
 /**
  * Attribute
- * Reusable key-value pair for request/response payloads.
  */
 export type Attribute = {
   /**
@@ -594,6 +593,19 @@ export type BulkSampleItemResponse = {
    * Files Skipped
    */
   files_skipped?: number
+}
+
+/**
+ * ChatRequest
+ * Request body sent by useChat: the full UIMessage history.
+ */
+export type ChatRequest = {
+  /**
+   * Messages
+   */
+  messages: Array<{
+    [key: string]: unknown
+  }>
 }
 
 /**
@@ -1511,7 +1523,7 @@ export type PipelineCreate = {
   /**
    * Attributes
    */
-  attributes?: Array<Attribute> | null
+  attributes?: Array<ApiWorkflowModelsAttribute> | null
   /**
    * Workflow Ids
    */
@@ -1545,7 +1557,7 @@ export type PipelinePublic = {
   /**
    * Attributes
    */
-  attributes?: Array<Attribute> | null
+  attributes?: Array<ApiWorkflowModelsAttribute> | null
   /**
    * Workflows
    */
@@ -1647,7 +1659,7 @@ export type ProjectCreate = {
   /**
    * Attributes
    */
-  attributes?: Array<ApiProjectModelsAttribute> | null
+  attributes?: Array<Attribute> | null
 }
 
 /**
@@ -1685,7 +1697,7 @@ export type ProjectPublic = {
   /**
    * Attributes
    */
-  attributes: Array<ApiProjectModelsAttribute> | null
+  attributes: Array<Attribute> | null
   /**
    * Sequencing Runs
    */
@@ -1704,7 +1716,7 @@ export type ProjectUpdate = {
   /**
    * Attributes
    */
-  attributes?: Array<ApiProjectModelsAttribute> | null
+  attributes?: Array<Attribute> | null
 }
 
 /**
@@ -2148,6 +2160,10 @@ export type SamplePublic = {
    * Run Id
    */
   run_id?: string | null
+  /**
+   * Created At
+   */
+  created_at?: string | null
 }
 
 /**
@@ -2228,6 +2244,10 @@ export type SampleWithFilesPublic = {
    * Run Id
    */
   run_id?: string | null
+  /**
+   * Created At
+   */
+  created_at?: string | null
   /**
    * Files
    */
@@ -2900,7 +2920,7 @@ export type WorkflowCreate = {
   /**
    * Attributes
    */
-  attributes?: Array<Attribute> | null
+  attributes?: Array<ApiWorkflowModelsAttribute> | null
 }
 
 /**
@@ -2970,7 +2990,7 @@ export type WorkflowPublic = {
   /**
    * Attributes
    */
-  attributes?: Array<Attribute> | null
+  attributes?: Array<ApiWorkflowModelsAttribute> | null
   /**
    * Versions
    */
@@ -3052,7 +3072,7 @@ export type WorkflowVersionCreate = {
   /**
    * Attributes
    */
-  attributes?: Array<Attribute> | null
+  attributes?: Array<ApiWorkflowModelsAttribute> | null
 }
 
 /**
@@ -3090,7 +3110,7 @@ export type WorkflowVersionPublic = {
   /**
    * Attributes
    */
-  attributes?: Array<Attribute> | null
+  attributes?: Array<ApiWorkflowModelsAttribute> | null
 }
 
 /**
@@ -3123,7 +3143,7 @@ export type WorkflowVersionSummary = {
 /**
  * Attribute
  */
-export type ApiProjectModelsAttribute = {
+export type ApiSamplesModelsAttribute = {
   /**
    * Key
    */
@@ -3136,8 +3156,9 @@ export type ApiProjectModelsAttribute = {
 
 /**
  * Attribute
+ * Reusable key-value pair for request/response payloads.
  */
-export type ApiSamplesModelsAttribute = {
+export type ApiWorkflowModelsAttribute = {
   /**
    * Key
    */
@@ -3858,6 +3879,29 @@ export type GetActionTypesResponses = {
 
 export type GetActionTypesResponse =
   GetActionTypesResponses[keyof GetActionTypesResponses]
+
+export type ChatData = {
+  body: ChatRequest
+  path?: never
+  query?: never
+  url: '/api/v1/chat'
+}
+
+export type ChatErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError
+}
+
+export type ChatError = ChatErrors[keyof ChatErrors]
+
+export type ChatResponses = {
+  /**
+   * Successful Response
+   */
+  200: unknown
+}
 
 export type ListFilesData = {
   body?: never
@@ -6902,5 +6946,5 @@ export type SearchUsersResponse =
   SearchUsersResponses[keyof SearchUsersResponses]
 
 export type ClientOptions = {
-  baseURL: 'http://apiserver:3000' | (string & {})
+  baseUrl: 'http://localhost:3000' | (string & {})
 }

--- a/src/components/validate-manifest-form.tsx
+++ b/src/components/validate-manifest-form.tsx
@@ -186,7 +186,7 @@ export const ValidateManifestForm: React.FC<ValidateManifestFormProps> = ({
         throwOnError: true,
       }).then((response) => {
         // Check if response has status 204 (no content)
-        if (response.status === 204) {
+        if (response.response.status === 204) {
           dispatch({ type: 'SET_LATEST_MANIFEST_PATH', value: 'There is no matching manifest file associated with this vendor' });
           dispatch({ type: 'SET_MANIFEST_ERROR', value: true });
         } else if (response.data) {

--- a/src/hey-api.ts
+++ b/src/hey-api.ts
@@ -5,7 +5,7 @@ const API_URL = import.meta.env.VITE_API_URL
 export const createClientConfig: CreateClientConfig = (config) => {
   const clientConfig = {
     ...config,
-    baseURL: API_URL,
+    baseUrl: API_URL,
   }
   return clientConfig
 }

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -1,0 +1,35 @@
+/**
+ * HTTP error thrown by the generated fetch client. Constructed in the
+ * client's error interceptor (see interceptors.ts) so app code always
+ * receives the status code, parsed body, and request context together —
+ * the same information AxiosError used to carry.
+ */
+export class ApiError extends Error {
+  constructor(
+    readonly status: number,
+    readonly statusText: string,
+    readonly body: unknown,
+    readonly method: string,
+    readonly url: string,
+  ) {
+    super(`HTTP ${status} ${statusText}`.trim() + ` from ${method} ${url}`)
+    this.name = 'ApiError'
+  }
+}
+
+/**
+ * The server could not be reached at all (connection refused, DNS failure,
+ * offline). Wraps fetch's bare TypeError with the request context.
+ * Thrown by fetchWithAuth; aborts are NOT wrapped (they surface as
+ * AbortError so callers can distinguish cancellation).
+ */
+export class NetworkError extends Error {
+  constructor(
+    readonly method: string,
+    readonly url: string,
+    cause: unknown,
+  ) {
+    super(cause instanceof Error ? cause.message : String(cause))
+    this.name = 'NetworkError'
+  }
+}

--- a/src/lib/auth-fetch.ts
+++ b/src/lib/auth-fetch.ts
@@ -1,0 +1,58 @@
+import { NetworkError } from './api-error'
+import { getAccessToken, refreshAccessToken } from './auth-token'
+
+// A 401 from these endpoints must never trigger a session refresh: a failed
+// login is just a failed login, and a 401 from the refresh endpoint *inside*
+// refreshAccessToken() would await its own single-flight promise and deadlock.
+const AUTH_ENDPOINTS = ['/api/v1/auth/login', '/api/v1/auth/refresh']
+
+/**
+ * The app's authenticated fetch: attaches the Bearer token, and on a 401
+ * refreshes the session (single-flight, via auth-token.ts) and retries the
+ * request once. Connection failures are wrapped into NetworkError with the
+ * request context; aborts pass through as AbortError.
+ *
+ * This is the `fetch` implementation for the generated hey-api client (see
+ * interceptors.ts) and for anything else fetch-based, e.g. the AI chat
+ * transport — one auth path for every request the app makes.
+ */
+export const fetchWithAuth: typeof fetch = async (input, init) => {
+  const url = input instanceof Request ? input.url : String(input)
+  const method = (
+    init?.method ?? (input instanceof Request ? input.method : 'GET')
+  ).toUpperCase()
+
+  const send = async (freshToken?: string) => {
+    const baseHeaders =
+      init?.headers ?? (input instanceof Request ? input.headers : undefined)
+    const headers = new Headers(baseHeaders)
+    const token = freshToken ?? getAccessToken()
+    if (token) headers.set('Authorization', `Bearer ${token}`)
+    try {
+      // Clone Request inputs so the body is still consumable on the retry
+      return await fetch(input instanceof Request ? input.clone() : input, {
+        ...init,
+        headers,
+      })
+    } catch (error) {
+      if (error instanceof TypeError) {
+        throw new NetworkError(method, url, error)
+      }
+      throw error
+    }
+  }
+
+  const response = await send()
+  if (response.status !== 401) return response
+  if (AUTH_ENDPOINTS.some((endpoint) => url.includes(endpoint))) {
+    return response
+  }
+
+  let newToken: string
+  try {
+    newToken = await refreshAccessToken()
+  } catch {
+    return response // session expired — surface the original 401
+  }
+  return send(newToken)
+}

--- a/src/lib/auth-token.ts
+++ b/src/lib/auth-token.ts
@@ -1,0 +1,46 @@
+import { refreshToken as refreshTokenApi } from '../client/sdk.gen'
+import { STORAGE_KEYS } from '../context/auth-context'
+
+let refreshPromise: Promise<string> | null = null
+
+export function getAccessToken(): string | null {
+  return localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN)
+}
+
+/**
+ * Refresh the access token, deduplicating concurrent callers onto a single
+ * in-flight request — callers that arrive while a refresh is running await
+ * the same promise. On success the new tokens are persisted; on failure the
+ * session is cleared and `auth:session-expired` is dispatched.
+ */
+export function refreshAccessToken(): Promise<string> {
+  refreshPromise ??= doRefresh().finally(() => {
+    refreshPromise = null
+  })
+  return refreshPromise
+}
+
+async function doRefresh(): Promise<string> {
+  try {
+    const storedRefreshToken = localStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN)
+    if (!storedRefreshToken) throw new Error('No refresh token available')
+
+    const { data } = await refreshTokenApi({
+      throwOnError: true,
+      body: { refresh_token: storedRefreshToken },
+    })
+
+    const expiresAt = Date.now() + data.expires_in * 1000
+    localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, data.access_token)
+    localStorage.setItem(STORAGE_KEYS.REFRESH_TOKEN, data.refresh_token)
+    localStorage.setItem(STORAGE_KEYS.EXPIRES_AT, expiresAt.toString())
+
+    return data.access_token
+  } catch (error) {
+    localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN)
+    localStorage.removeItem(STORAGE_KEYS.REFRESH_TOKEN)
+    localStorage.removeItem(STORAGE_KEYS.EXPIRES_AT)
+    window.dispatchEvent(new Event('auth:session-expired'))
+    throw error
+  }
+}

--- a/src/lib/error-utils.ts
+++ b/src/lib/error-utils.ts
@@ -1,5 +1,5 @@
-import { AxiosError } from 'axios'
 import { toast } from 'sonner'
+import { ApiError, NetworkError } from './api-error'
 
 export type ErrorKind = 'server' | 'network' | 'client' | 'unknown'
 
@@ -11,18 +11,22 @@ export interface FriendlyError {
   detail?: string
 }
 
-function extractDetail(err: AxiosError<{ detail?: unknown } | undefined>): string | undefined {
-  const raw = err.response?.data?.detail
+function extractDetail(body: unknown): string | undefined {
+  const raw = (body as { detail?: unknown } | undefined)?.detail
   if (typeof raw === 'string' && raw.trim()) return raw
   if (Array.isArray(raw) && raw.length > 0) {
     const first = raw[0] as { msg?: string } | string | undefined
     if (typeof first === 'string') return first
-    if (first && typeof first === 'object' && typeof first.msg === 'string') return first.msg
+    if (first && typeof first === 'object' && typeof first.msg === 'string')
+      return first.msg
   }
   return undefined
 }
 
-function specificFriendlyError(status: number, detail: string | undefined): FriendlyError | undefined {
+function specificFriendlyError(
+  status: number,
+  detail: string | undefined,
+): FriendlyError | undefined {
   switch (status) {
     case 400:
       return {
@@ -30,7 +34,8 @@ function specificFriendlyError(status: number, detail: string | undefined): Frie
         status,
         title: "That request wasn't accepted",
         description:
-          detail ?? "The server couldn't process this request. Please review your input and try again.",
+          detail ??
+          "The server couldn't process this request. Please review your input and try again.",
         detail,
       }
     case 401:
@@ -57,7 +62,8 @@ function specificFriendlyError(status: number, detail: string | undefined): Frie
         status,
         title: "We couldn't find that",
         description:
-          detail ?? "The item you're looking for may have been moved, renamed, or deleted.",
+          detail ??
+          "The item you're looking for may have been moved, renamed, or deleted.",
         detail,
       }
     case 409:
@@ -75,7 +81,8 @@ function specificFriendlyError(status: number, detail: string | undefined): Frie
         kind: 'client',
         status,
         title: 'Some fields need attention',
-        description: detail ?? 'Please review the highlighted fields and try again.',
+        description:
+          detail ?? 'Please review the highlighted fields and try again.',
         detail,
       }
     case 429:
@@ -104,25 +111,23 @@ function specificFriendlyError(status: number, detail: string | undefined): Frie
 }
 
 export function classifyError(error: unknown): FriendlyError {
-  if (error instanceof AxiosError) {
-    const status = error.response?.status
-    const detail = extractDetail(error as AxiosError<{ detail?: unknown }>)
-
-    if (!error.response) {
-      return {
-        kind: 'network',
-        title: "We couldn't reach the server",
-        description:
-          'Check your internet connection and try again. If the problem persists, the service may be briefly offline.',
-      }
+  if (error instanceof NetworkError) {
+    return {
+      kind: 'network',
+      title: "We couldn't reach the server",
+      description:
+        'Check your internet connection and try again. If the problem persists, the service may be briefly offline.',
     }
+  }
 
-    if (status !== undefined) {
-      const specific = specificFriendlyError(status, detail)
-      if (specific) return specific
-    }
+  if (error instanceof ApiError) {
+    const { status } = error
+    const detail = extractDetail(error.body)
 
-    if (status !== undefined && status >= 500) {
+    const specific = specificFriendlyError(status, detail)
+    if (specific) return specific
+
+    if (status >= 500) {
       return {
         kind: 'server',
         status,
@@ -133,12 +138,14 @@ export function classifyError(error: unknown): FriendlyError {
       }
     }
 
-    if (status !== undefined && status >= 400) {
+    if (status >= 400) {
       return {
         kind: 'client',
         status,
         title: 'The request could not be completed',
-        description: detail ?? 'The server rejected the request. Please review your input and try again.',
+        description:
+          detail ??
+          'The server rejected the request. Please review your input and try again.',
         detail,
       }
     }
@@ -149,33 +156,37 @@ export function classifyError(error: unknown): FriendlyError {
     kind: 'unknown',
     title: 'Something went wrong',
     description:
-      message ?? 'An unexpected error occurred. Please try again, or reload the page if the problem continues.',
+      message ??
+      'An unexpected error occurred. Please try again, or reload the page if the problem continues.',
     detail: message,
   }
 }
 
 export function isServerError(error: unknown): boolean {
-  return error instanceof AxiosError && (error.response?.status ?? 0) >= 500
+  return error instanceof ApiError && error.status >= 500
 }
 
 /**
  * Describe an error for the "Show technical details" panel in a way that's
  * useful to forward to a support person. Prefers the backend's `detail`
- * message; for AxiosErrors with no detail, describes the HTTP exchange
+ * message; for HTTP errors with no detail, describes the HTTP exchange
  * (method, URL, status) rather than the JS stack — so a 503 reads as a
- * backend problem, not an "AxiosError". Falls back to stack/message for
- * non-Axios errors.
+ * backend problem, not a JS error. Falls back to stack/message for
+ * other errors.
  */
-export function getTechnicalDetail(error: unknown, info: FriendlyError): string {
+export function getTechnicalDetail(
+  error: unknown,
+  info: FriendlyError,
+): string {
   if (info.detail) return info.detail
-  if (error instanceof AxiosError) {
-    const method = error.config?.method?.toUpperCase() ?? 'REQUEST'
-    const url = error.config?.url ?? '(unknown URL)'
-    if (error.response) {
-      const statusText = error.response.statusText || ''
-      return `HTTP ${error.response.status} ${statusText}`.trim() + ` from ${method} ${url}\nThe server did not provide additional details.`
-    }
-    return `${method} ${url}\nNo response from server: ${error.message}`
+  if (error instanceof ApiError) {
+    return (
+      `HTTP ${error.status} ${error.statusText}`.trim() +
+      ` from ${error.method.toUpperCase()} ${error.url}\nThe server did not provide additional details.`
+    )
+  }
+  if (error instanceof NetworkError) {
+    return `${error.method} ${error.url}\nNo response from server: ${error.message}`
   }
   if (error instanceof Error) return error.stack ?? error.message
   return String(error)
@@ -199,7 +210,10 @@ export function toastApiError(error: unknown, fallbackTitle: string): void {
  * Return a single-line error message suitable for inline form display
  * (e.g. react-hook-form's `setError('root', { message })`).
  */
-export function getFormApiErrorMessage(error: unknown, fallbackTitle: string): string {
+export function getFormApiErrorMessage(
+  error: unknown,
+  fallbackTitle: string,
+): string {
   const info = classifyError(error)
   if (info.kind === 'server' || info.kind === 'network') return info.description
   return info.detail ?? fallbackTitle

--- a/src/lib/interceptors.ts
+++ b/src/lib/interceptors.ts
@@ -1,83 +1,22 @@
-import { client } from "../client/client.gen";
-import { refreshToken as refreshTokenApi } from "../client/sdk.gen";
-import { STORAGE_KEYS } from "../context/auth-context";
+import { client } from '../client/client.gen'
+import { ApiError } from './api-error'
+import { fetchWithAuth } from './auth-fetch'
 
-const api = client.instance;
+// All generated-SDK requests go out through fetchWithAuth, which attaches the
+// Bearer token and handles 401 → single-flight refresh → retry. The same
+// function backs the AI chat transport, so the whole app shares one auth path.
+client.setConfig({ fetch: fetchWithAuth })
 
-// Track whether a refresh is already in-flight to avoid concurrent refresh calls
-let isRefreshing = false;
-let refreshSubscribers: Array<{ resolve: (token: string) => void; reject: (err: unknown) => void }> = [];
-
-api.interceptors.request.use((config) => {
-  const token = localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
-  }
-  return config;
-});
-
-api.interceptors.response.use(
-  (response) => response,
-  async (error) => {
-    const originalRequest = error.config;
-
-    // Only intercept 401s; skip the refresh endpoint itself to avoid infinite loops
-    if (
-      error.response?.status !== 401 ||
-      originalRequest._retry ||
-      originalRequest.url?.includes('/api/v1/auth/login') ||
-      originalRequest.url?.includes('/api/v1/auth/refresh')
-    ) {
-      return Promise.reject(error);
-    }
-
-    // If a refresh is already in-flight, queue this request
-    if (isRefreshing) {
-      return new Promise((resolve, reject) => {
-        refreshSubscribers.push({
-          resolve: (newToken) => {
-            originalRequest.headers.Authorization = `Bearer ${newToken}`;
-            resolve(api(originalRequest));
-          },
-          reject,
-        });
-      });
-    }
-
-    originalRequest._retry = true;
-    isRefreshing = true;
-
-    try {
-      const storedRefreshToken = localStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN);
-      if (!storedRefreshToken) throw new Error('No refresh token available');
-
-      const { data } = await refreshTokenApi({
-        throwOnError: true,
-        body: { refresh_token: storedRefreshToken },
-      });
-
-      // Persist the new tokens
-      const expiresAt = Date.now() + data.expires_in * 1000;
-      localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, data.access_token);
-      localStorage.setItem(STORAGE_KEYS.REFRESH_TOKEN, data.refresh_token);
-      localStorage.setItem(STORAGE_KEYS.EXPIRES_AT, expiresAt.toString());
-
-      // Drain queued requests and retry the original
-      refreshSubscribers.forEach(({ resolve }) => resolve(data.access_token));
-      refreshSubscribers = [];
-      originalRequest.headers.Authorization = `Bearer ${data.access_token}`;
-      return api(originalRequest);
-    } catch (refreshError) {
-      // Refresh failed — reject all queued requests and clear storage
-      refreshSubscribers.forEach(({ reject }) => reject(refreshError));
-      refreshSubscribers = [];
-      localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN);
-      localStorage.removeItem(STORAGE_KEYS.REFRESH_TOKEN);
-      localStorage.removeItem(STORAGE_KEYS.EXPIRES_AT);
-      window.dispatchEvent(new Event('auth:session-expired'));
-      return Promise.reject(refreshError);
-    } finally {
-      isRefreshing = false;
-    }
-  }
-);
+// Non-2xx responses: the fetch client parses the error body and throws it.
+// Wrap it into ApiError so error handling (lib/error-utils.ts) receives the
+// status code and request context alongside the parsed body.
+client.interceptors.error.use(
+  (error, response, request) =>
+    new ApiError(
+      response.status,
+      response.statusText,
+      error,
+      request.method,
+      request.url,
+    ),
+)

--- a/src/routes/_auth.projects.$project_id.index.tsx
+++ b/src/routes/_auth.projects.$project_id.index.tsx
@@ -105,7 +105,7 @@ function RouteComponent() {
       )
     },
     onError: (err) => {
-      toast.error(`Error uploading sample metadata: ${err.message || 'Unknown error'}`)
+      toast.error(`Error uploading sample metadata: ${err instanceof Error ? err.message : 'Unknown error'}`)
     },
   })
 

--- a/src/routes/_auth.runs.$run_id.indexqc.index.tsx
+++ b/src/routes/_auth.runs.$run_id.indexqc.index.tsx
@@ -21,7 +21,7 @@ export const Route = createFileRoute('/_auth/runs/$run_id/indexqc/')({
       throwOnError: true,
     });
 
-    if (res.status === 204) throw notFound();
+    if (res.response.status === 204) throw notFound();
 
     return ({
       runMetrics: res.data


### PR DESCRIPTION
## Summary

- Switch hey-api codegen from `@hey-api/client-axios` to `@hey-api/client-fetch` and regenerate `src/client` (`baseURL` → `baseUrl`)
- All SDK requests now flow through `fetchWithAuth` (`src/lib/auth-fetch.ts`): Bearer attach + single-flight 401 refresh-and-retry (`src/lib/auth-token.ts`), with auth endpoints excluded so a 401 from the refresh call can't recurse
- Non-2xx responses are wrapped into `ApiError` (status, statusText, parsed body, method, url) via the client error interceptor; connection failures into `NetworkError` (`src/lib/api-error.ts`)
- `error-utils.ts` produces identical `FriendlyError` output, keyed off `ApiError`/`NetworkError` instead of `AxiosError`
- Update the three call sites that read axios shapes (two 204 checks, one `onError` message)
- Remove `axios`

## Why

One auth path for every request the app makes — including fetch-only consumers such as streaming endpoints, which axios/XHR cannot support — and one less HTTP stack in the bundle.

## Expected behavior

- All API calls behave exactly as before: same token attach, silent 401 → refresh → retry, and session-expired logout when refresh fails
- Error toasts, form messages, and the technical-details panel show the same titles/messages for every status (400/401/403/404/409/422/429/5xx), network failures, and unknown errors
- Manifest 204 ("no matching manifest") and IndexQC not-found flows unchanged
- File uploads unchanged (FormData over fetch); note fetch cannot report upload progress — not currently used anywhere
- No user-visible changes anywhere in the app
