### PR TITLE
Run CI on pull requests again, for every base branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
       - develop
+  # No branches: filter. With one, a pull request targeting anything other than
+  # main or develop gets no CI at all -- which is how a 30-file diff carrying a
+  # generator major-version bump and a Node image change (#89, based on a feature
+  # branch) reached main having been checked by nothing.
+  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
`de3e4c3` removed the `pull_request` trigger **entirely** rather than removing its `branches:` filter:

```diff
-  pull_request:
-    branches:
-      - main
-      - develop
```

So `build.yml` now fires only on `push` to main/develop and `workflow_dispatch` — meaning **no pull request gets CI at all**, and tests and the build run only after a merge has already landed on main. That is worse than the filter it replaced, which at least checked PRs targeting main.

My wording caused this — "dropping the `branches:` filter" was ambiguous. What was meant is keeping the trigger and removing only the filter:

```yaml
  pull_request:
```

GitHub defaults to every base branch when `pull_request` carries no filter, which is the point: a **stacked** PR based on a feature branch gets checked too. #89 — 30 files, a generator major-version bump, a Node image change — reached `main` having been checked by nothing, because its base was a feature branch.

`push` on main and develop stays, so a merge is still verified after the fact.

## Whether this self-verifies

For a same-repo PR, GitHub evaluates workflows at the merge ref, which contains this change — so a `build` check may well appear on this PR despite the trigger being absent from `main`. I am not certain either way; whatever the checks show below is the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)